### PR TITLE
feat: adding docker compose for local apollo network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,17 +4055,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9961b98f55dc0b2737000132505bdafa249abab147ee9de43c50ae04a054aa6c"
+
+[[package]]
 name = "keystore"
 version = "0.1.0"
-source = "git+https://github.com/deltadevsde/keystore?rev=40f21a41afd0654091bb0881665288034ab8533f#40f21a41afd0654091bb0881665288034ab8533f"
+source = "git+https://github.com/deltadevsde/keystore?rev=044d06f429400ff71544daac664d10f865851939#044d06f429400ff71544daac664d10f865851939"
 dependencies = [
  "aes-gcm",
+ "base64 0.22.1",
  "dotenvy",
  "ed25519-dalek",
  "hex 0.4.3",
+ "keyring",
  "mockall",
  "rand 0.8.5",
- "security-framework",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ ahash = "0.8.7"
 celestia-rpc = "0.2.0"
 celestia-types = "0.2.0"
 mockall = "0.12.1"
-keystore = { git = "https://github.com/deltadevsde/keystore", rev = "40f21a41afd0654091bb0881665288034ab8533f" }
+keystore = { git = "https://github.com/deltadevsde/keystore", rev = "044d06f429400ff71544daac664d10f865851939" }
 pyroscope = "0.5.7"
 pyroscope_pprofrs = "0.2.7"
 toml = "0.8.14"

--- a/ci/Dockerfile.apollo
+++ b/ci/Dockerfile.apollo
@@ -1,0 +1,62 @@
+# This Dockerfile performs a multi-stage build. BUILDER_IMAGE is the image used
+# to compile the celestia-appd binary. RUNTIME_IMAGE is the image that will be
+# returned with the final celestia-appd binary.
+#
+# Separating the builder and runtime image allows the runtime image to be
+# considerably smaller because it doesn't need to have Golang installed.
+ARG BUILDER_IMAGE=docker.io/golang:1.22.1-alpine3.18
+ARG RUNTIME_IMAGE=docker.io/alpine:3.19.1
+ARG TARGETOS
+ARG TARGETARCH
+
+# Stage 1: Build the celestia-appd binary inside a builder image that will be discarded later.
+# Ignore hadolint rule because hadolint can't parse the variable.
+# See https://github.com/hadolint/hadolint/issues/339
+# hadolint ignore=DL3006
+FROM --platform=$BUILDPLATFORM ${BUILDER_IMAGE} AS builder
+ENV CGO_ENABLED=0
+ENV GO111MODULE=on
+# hadolint ignore=DL3018
+RUN apk update && apk add --no-cache \
+    gcc \
+    git \
+    # linux-headers are needed for Ledger support
+    linux-headers \
+    make \
+    musl-dev
+
+RUN apk --no-cache add git
+
+RUN git clone https://github.com/cmwaters/apollo.git /apollo
+
+WORKDIR /apollo
+RUN uname -a &&\
+    CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go install cmd/apollo.go
+
+FROM ${RUNTIME_IMAGE} AS runtime
+# Use UID 10,001 because UIDs below 10,000 are a security risk.
+# Ref: https://github.com/hexops/dockerfile/blob/main/README.md#do-not-use-a-uid-below-10000
+ARG UID=10001
+ARG USER_NAME=apollo
+ENV APOLLO_HOME=/home/${USER_NAME}
+# hadolint ignore=DL3018
+RUN apk update && apk add --no-cache \
+    bash \
+    curl \
+    jq \
+    && adduser ${USER_NAME} \
+    -D \
+    -g ${USER_NAME} \
+    -h ${APOLLO_HOME} \
+    -s /sbin/nologin \
+    -u ${UID}
+
+COPY --from=builder /apollo/apollo /bin/apollo
+
+# Set the user
+USER ${USER_NAME}
+
+# Expose ports:
+EXPOSE 1317 9090 26657 1095 8080 26658
+ENTRYPOINT [ "/bin/bash", "apollo" ]

--- a/ci/Dockerfile.deimos
+++ b/ci/Dockerfile.deimos
@@ -1,0 +1,26 @@
+FROM rust:1.79-alpine as build
+
+RUN USER=root cargo new --bin deimos
+WORKDIR /deimos
+
+RUN apk --no-cache add protobuf protobuf-dev
+RUN apk add --no-cache openssl
+RUN apk add --no-cache pkgconf
+RUN apk add --no-cache musl-dev libressl-dev
+
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+
+RUN cargo build --release
+RUN rm src/*.rs
+
+# copy your source tree
+COPY ./src ./src
+
+# 3. Build only the dependencies to cache them
+RUN rm ./target/release/deps/deimos*
+RUN cargo build --release
+
+FROM rust:1.79
+COPY --from=build /deimos/target/release/deimos .
+CMD ./deimos $NODE_TYPE

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,0 +1,44 @@
+services:
+  apollo:
+    image: apollo
+    build:
+      dockerfile: Dockerfile.apollo
+      context: .
+    restart: always
+    network_mode: "host"
+
+  deimos-sequencer:
+    image: deimos
+    build:
+      dockerfile: ci/Dockerfile.deimos
+      context: ../
+    environment:
+      - NODE_TYPE=--port=8081 sequencer
+    restart: always
+    depends_on:
+      - apollo
+      - redis
+    network_mode: "host"
+
+  deimos-lightclient:
+    image: deimos
+    build:
+      dockerfile: ci/Dockerfile.deimos
+      context: ../
+    environment:
+      - NODE_TYPE=light-client
+      - ARGS="-r redis://host.docker.internal:6379"
+    restart: always
+    depends_on:
+      - apollo
+      - deimos-sequencer
+    network_mode: "host"
+
+  redis:
+    image: redis
+    restart: always
+    ports:
+      - 6379:6379
+    expose:
+      - 6379
+    network_mode: "host"


### PR DESCRIPTION
Not done yet: 
- the keyring change should be upstreamed first
- light client isn't funded automatically
- apollo-1 logs are insanely annoying because of node spamming blob: not found for empty heights