### PR TITLE
ci: adding redis, enabling tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: cargo build --verbose
 
       - name: Run tests
-        run: cargo test --features ci --verbose
+        run: cargo test --features ci --verbose -- --test-threads=1
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,12 @@ jobs:
             profile: default
           - version: nightly
             profile: default
-
+        
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
 
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +47,14 @@ jobs:
 
       - name: Install dependencies
         run: cargo fetch
+
+      - name: Wait for Redis to start
+        run: |
+          while ! nc -z localhost 6379; do
+            echo "Waiting for Redis..."
+            sleep 1
+          done
+        shell: bash
 
       # can execute code formatting, to be enabled later
       # there are some oddities with it being configured to ONLY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,8 @@ jobs:
         run: cargo build --verbose
 
       - name: Run tests
-        run: cargo test --verbose -- --test-threads=1
-
+        run: cargo test --verbose 
+        
       - name: Install cargo-audit
         run: cargo install cargo-audit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: cargo build --verbose
 
       - name: Run tests
-        run: cargo test --features ci --verbose -- --test-threads=1
+        run: cargo test --verbose -- --test-threads=1
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -235,7 +235,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
+checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
 dependencies = [
  "flate2",
  "futures-core",
@@ -759,7 +759,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1212,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
@@ -1438,7 +1438,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1836,7 +1836,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1950,7 +1950,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2115,7 +2115,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2440,7 +2440,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2592,7 +2592,7 @@ dependencies = [
  "gix-utils",
  "itoa 1.0.11",
  "thiserror",
- "winnow 0.6.13",
+ "winnow 0.6.14",
 ]
 
 [[package]]
@@ -2674,7 +2674,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow 0.6.13",
+ "winnow 0.6.14",
 ]
 
 [[package]]
@@ -2895,7 +2895,7 @@ checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2930,7 +2930,7 @@ dependencies = [
  "itoa 1.0.11",
  "smallvec",
  "thiserror",
- "winnow 0.6.13",
+ "winnow 0.6.14",
 ]
 
 [[package]]
@@ -3054,7 +3054,7 @@ dependencies = [
  "gix-utils",
  "maybe-async",
  "thiserror",
- "winnow 0.6.13",
+ "winnow 0.6.14",
 ]
 
 [[package]]
@@ -3087,7 +3087,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror",
- "winnow 0.6.13",
+ "winnow 0.6.14",
 ]
 
 [[package]]
@@ -4280,7 +4280,7 @@ checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4374,7 +4374,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4636,9 +4636,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if 1.0.0",
@@ -4657,7 +4657,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4668,9 +4668,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -4825,7 +4825,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -4866,7 +4866,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5035,7 +5035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5095,6 +5095,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "serial_test",
  "thiserror",
  "tokio",
  "toml 0.8.15",
@@ -5214,7 +5215,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types",
  "regex",
- "syn 2.0.71",
+ "syn 2.0.72",
  "tempfile",
 ]
 
@@ -5241,7 +5242,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -5328,14 +5329,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+checksum = "25a78e6f726d84fcf960409f509ae354a32648f090c8d32a2ea8b1a1bc3bab14"
 dependencies = [
  "libc",
  "once_cell",
  "socket2 0.5.7",
- "tracing",
  "windows-sys 0.52.0",
 ]
 
@@ -5766,7 +5766,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.71",
+ "syn 2.0.72",
  "walkdir",
 ]
 
@@ -6007,6 +6007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4465c22496331e20eb047ff46e7366455bc01c0c02015c4a376de0b2cd3a1af"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6030,6 +6039,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85f05a494052771fc5bd0619742363b5e24e5ad72ab3111ec2e27925b8edc5f3"
 
 [[package]]
 name = "secrecy"
@@ -6117,7 +6132,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6149,7 +6164,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6171,6 +6186,31 @@ dependencies = [
  "itoa 1.0.11",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6208,9 +6248,9 @@ dependencies = [
 
 [[package]]
 name = "sha1_smol"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -6434,9 +6474,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6569,7 +6609,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6666,7 +6706,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -6835,7 +6875,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.14",
 ]
 
 [[package]]
@@ -6910,7 +6950,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -7134,7 +7174,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -7250,7 +7290,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -7284,7 +7324,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7510,9 +7550,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "374ec40a2d767a3c1b4972d9475ecd557356637be906f2cb3f7fe17a6eb5e22f"
 dependencies = [
  "memchr",
 ]
@@ -7572,7 +7612,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -7592,7 +7632,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ readme = "README.md"
 [features]
 default = []
 key_transparency = []
-ci = []
 
 [dependencies]
 axum = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rand = "0.8.5"
 rand07 = { package = "rand", version = "0.7.0" }
 hex = "0.4.3"
 ff = "0.13.0"
-openssl = "0.10.62"
+openssl = "0.10.66"
 futures = "0.3"
 lazy_static = "1.4"
 colored = "2.0.0"
@@ -66,3 +66,6 @@ pyroscope = "0.5.7"
 pyroscope_pprofrs = "0.2.7"
 toml = "0.8.14"
 dirs = "5.0.1"
+
+[dev-dependencies]
+serial_test = "3.1.1"

--- a/src/node_types/sequencer.rs
+++ b/src/node_types/sequencer.rs
@@ -23,12 +23,11 @@ use tokio::{
 use crate::{
     cfg::Config,
     da::{DataAvailabilityLayer, EpochJson},
-    error::{PrismError, GeneralError},
+    error::{GeneralError, PrismError},
     node_types::NodeType,
     storage::{ChainEntry, Database, IncomingEntry, Operation},
     utils::verify_signature,
-    webserver::UpdateEntryJson,
-    webserver::WebServer,
+    webserver::{UpdateEntryJson, WebServer},
     zk_snark::BatchMerkleProofCircuit,
 };
 
@@ -465,11 +464,14 @@ impl Sequencer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cfg::{Config, RedisConfig};
-    use crate::da::mock::LocalDataAvailabilityLayer;
-    use crate::storage::RedisConnection;
+    use crate::{
+        cfg::{Config, RedisConfig},
+        da::mock::LocalDataAvailabilityLayer,
+        storage::RedisConnection,
+    };
     use base64::{engine::general_purpose::STANDARD as engine, Engine as _};
     use keystore_rs::create_signing_key;
+    use serial_test::serial;
 
     // set up redis connection and flush database before each test
     fn setup_db() -> RedisConnection {
@@ -501,6 +503,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_validate_and_queue_update() {
         let da_layer = Arc::new(LocalDataAvailabilityLayer::new());
         let db = Arc::new(setup_db());
@@ -525,6 +528,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_queued_update_gets_finalized() {
         let da_layer = Arc::new(LocalDataAvailabilityLayer::new());
         let db = Arc::new(setup_db());
@@ -566,6 +570,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_validate_invalid_update_fails() {
         let da_layer = Arc::new(LocalDataAvailabilityLayer::new());
         let db = Arc::new(setup_db());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -13,7 +13,7 @@ use std::{
 
 use crate::{
     cfg::RedisConfig,
-    error::{DatabaseError, PrismError, PrismResult, GeneralError},
+    error::{DatabaseError, GeneralError, PrismError, PrismResult},
     utils::parse_json_to_proof,
 };
 
@@ -400,7 +400,6 @@ impl Database for RedisConnection {
     }
 }
 
-#[cfg(not(feature = "ci"))]
 #[cfg(test)]
 mod tests {
     use indexed_merkle_tree::sha256_mod;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -402,9 +402,9 @@ impl Database for RedisConnection {
 
 #[cfg(test)]
 mod tests {
-    use indexed_merkle_tree::sha256_mod;
-
     use super::*;
+    use indexed_merkle_tree::sha256_mod;
+    use serial_test::serial;
 
     // Helper functions
 
@@ -444,6 +444,7 @@ mod tests {
     // probably not thaaat important
     // TODO: get_keys() returns the keys in reverse order
     #[test]
+    #[serial]
     fn test_get_keys() {
         // set up redis connection and flush database
         let redis_connections = setup();
@@ -478,6 +479,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_keys_from_empty_dictionary() {
         let redis_connections = setup();
 
@@ -492,6 +494,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[should_panic(expected = "assertion `left == right` failed")]
     fn test_get_too_much_returned_keys() {
         let redis_connections = setup();
@@ -522,6 +525,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     #[should_panic(expected = "assertion `left == right` failed")]
     fn test_get_too_little_returned_keys() {
         let redis_connections = setup();
@@ -561,6 +565,7 @@ mod tests {
     // TODO: shouldn't it be that the update function automatically continues the derived dict?
     // In addition, it should not be possible to write keys exclusively directly into the derived dict, right?
     #[test]
+    #[serial]
     fn test_get_hashed_keys() {
         let redis_connections = setup();
 
@@ -596,6 +601,7 @@ mod tests {
     // TESTS FOR fn get_hashchain(&self, key: &String) -> Result<Vec<ChainEntry>, &str>
 
     #[test]
+    #[serial]
     fn test_get_hashchain() {
         let redis_connections = setup();
 
@@ -616,6 +622,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_try_getting_hashchain_for_missing_key() {
         let redis_connections = setup();
 
@@ -634,6 +641,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_try_getting_wrong_formatted_hashchain_value() {
         let redis_connection = setup();
 
@@ -674,6 +682,7 @@ mod tests {
     // TESTS FOR fn get_derived_value(&self, key: &String) -> Result<String, &str>
 
     #[test]
+    #[serial]
     /*
         TODO: In the test writing, it is noticeable that things may either not have been named correctly here, or need to be reconsidered. The update_hashchain function receives an IncomingEntry and a Vec<ChainEntry> as parameters.
         The Vec<ChainEntry> is the current state of the hashchain, the IncomingEntry is the new entry to be added. is to be added. Now, in hindsight, I would have expected that within the function the new hashchain would be created,


### PR DESCRIPTION
- add redis to ci 
- use serial_test for redis tests so we can get rid of --test-threads=1
- fix cargo audit