### PR TITLE
feat: borsh serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,7 +3743,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexed-merkle-tree"
-version = "0.5.2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61914b61a7fbce596e07de3b014bb9277d2cbf56e55c5dcc152b15bb767ec00b"
 dependencies = [
  "borsh",
  "cargo-audit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases 0.2.1",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "syn_derive",
+]
+
+[[package]]
 name = "brotli"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1365,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -3714,9 +3744,8 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexed-merkle-tree"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea33f773b5f19b3b25f7927c7c70117f8b96538a91be20c6e1f6e63074601f4"
 dependencies = [
+ "borsh",
  "cargo-audit",
  "hex 0.4.3",
  "num",
@@ -4469,7 +4498,7 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if 1.0.0",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
  "libc",
 ]
 
@@ -5062,6 +5091,7 @@ dependencies = [
  "base64 0.22.1",
  "bellman",
  "bls12_381",
+ "borsh",
  "celestia-rpc",
  "celestia-types",
  "clap 4.5.9",
@@ -6481,6 +6511,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ clap = { version = "4.3.2", features = ["derive"] }
 config = "0.14.0"
 fs2 = "0.4.3"
 thiserror = "1.0.62"
-indexed-merkle-tree = { path = "../indexed-merkle-tree" }
+indexed-merkle-tree = "0.6.0"
 dotenvy = "0.15.7"
 ahash = "0.8.7"
 celestia-rpc = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ key_transparency = []
 
 [dependencies]
 axum = "0.6"
+borsh = { version = "1.5.1", features = ["derive"] }
 tower-http = { version = "0.4", features = ["cors"] }
 utoipa = { version = "3.3", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "3.1", features = ["axum"] }
@@ -55,7 +56,7 @@ clap = { version = "4.3.2", features = ["derive"] }
 config = "0.14.0"
 fs2 = "0.4.3"
 thiserror = "1.0.62"
-indexed-merkle-tree = "0.5.2"
+indexed-merkle-tree = { path = "../indexed-merkle-tree" }
 dotenvy = "0.15.7"
 ahash = "0.8.7"
 celestia-rpc = "0.2.0"

--- a/src/da/mod.rs
+++ b/src/da/mod.rs
@@ -1,19 +1,20 @@
 use crate::{
-    error::{DAResult, PrismResult, GeneralError},
+    error::{DAResult, GeneralError, PrismResult},
     utils::SignedContent,
     zk_snark::{Bls12Proof, VerifyingKey},
 };
 use async_trait::async_trait;
+use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519::Signature;
 use indexed_merkle_tree::Hash;
-use serde::{Deserialize, Serialize};
 use std::{self, str::FromStr};
 
 pub mod celestia;
 pub mod mock;
 
-#[derive(Serialize, Deserialize, Clone)]
-pub struct EpochJson {
+// FinalizedEpoch is the data structure that represents the finalized epoch data, and is posted to the DA layer.
+#[derive(BorshSerialize, BorshDeserialize, Clone)]
+pub struct FinalizedEpoch {
     pub height: u64,
     pub prev_commitment: Hash,
     pub current_commitment: Hash,
@@ -22,7 +23,7 @@ pub struct EpochJson {
     pub signature: Option<String>,
 }
 
-impl SignedContent for EpochJson {
+impl SignedContent for FinalizedEpoch {
     fn get_signature(&self) -> PrismResult<Signature> {
         match &self.signature {
             Some(signature) => Signature::from_str(signature)
@@ -31,10 +32,10 @@ impl SignedContent for EpochJson {
         }
     }
 
-    fn get_plaintext(&self) -> PrismResult<String> {
+    fn get_plaintext(&self) -> PrismResult<Vec<u8>> {
         let mut copy = self.clone();
         copy.signature = None;
-        serde_json::to_string(&copy).map_err(|e| GeneralError::EncodingError(e.to_string()).into())
+        borsh::to_vec(&copy).map_err(|e| GeneralError::EncodingError(e.to_string()).into())
     }
 
     fn get_public_key(&self) -> PrismResult<String> {
@@ -50,7 +51,7 @@ impl SignedContent for EpochJson {
 pub trait DataAvailabilityLayer: Send + Sync {
     async fn get_latest_height(&self) -> DAResult<u64>;
     async fn initialize_sync_target(&self) -> DAResult<u64>;
-    async fn get(&self, height: u64) -> DAResult<Vec<EpochJson>>;
-    async fn submit(&self, epoch: &EpochJson) -> DAResult<u64>;
+    async fn get(&self, height: u64) -> DAResult<Vec<FinalizedEpoch>>;
+    async fn submit(&self, epoch: &FinalizedEpoch) -> DAResult<u64>;
     async fn start(&self) -> DAResult<()>;
 }

--- a/src/node_types/lightclient.rs
+++ b/src/node_types/lightclient.rs
@@ -1,6 +1,6 @@
 use crate::{
     cfg::CelestiaConfig,
-    error::{DataAvailabilityError, PrismResult, GeneralError},
+    error::{DataAvailabilityError, GeneralError, PrismResult},
 };
 use async_trait::async_trait;
 use std::{self, sync::Arc, time::Duration};
@@ -102,7 +102,7 @@ impl LightClient {
                                         &epoch_json.clone(),
                                         self.verifying_key.clone(),
                                     ) {
-                                        Ok(i) => trace!("valid signature for epoch {}", i),
+                                        Ok(_) => trace!("valid signature for epoch {}", epoch_json.height),
                                         Err(e) => {
                                             panic!("invalid signature in epoch {}: {:?}", i, e)
                                         }

--- a/src/node_types/sequencer.rs
+++ b/src/node_types/sequencer.rs
@@ -396,8 +396,7 @@ impl Sequencer {
             }
         };
 
-        // utf8lossy
-        let json_string = String::from_utf8_lossy(&signed_content).to_string();
+        let json_string = String::from_utf8_lossy(&signed_content);
         let incoming: IncomingEntry = match serde_json::from_str(&json_string) {
             Ok(obj) => obj,
             Err(e) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -112,7 +112,7 @@ pub fn validate_epoch(
 
 pub trait SignedContent {
     fn get_signature(&self) -> PrismResult<Signature>;
-    fn get_plaintext(&self) -> PrismResult<String>;
+    fn get_plaintext(&self) -> PrismResult<Vec<u8>>;
     fn get_public_key(&self) -> PrismResult<String>;
 }
 
@@ -120,7 +120,7 @@ pub trait SignedContent {
 pub fn verify_signature<T: SignedContent>(
     item: &T,
     optional_public_key: Option<String>,
-) -> PrismResult<String> {
+) -> PrismResult<Vec<u8>> {
     let public_key_str = match optional_public_key {
         Some(key) => key,
         None => item.get_public_key()?,
@@ -132,7 +132,7 @@ pub fn verify_signature<T: SignedContent>(
     let content = item.get_plaintext()?;
     let signature = item.get_signature()?;
 
-    match public_key.verify(content.as_bytes(), &signature) {
+    match public_key.verify(content.as_slice(), &signature) {
         Ok(_) => Ok(content),
         Err(e) => Err(GeneralError::InvalidSignature(e).into()),
     }

--- a/src/webserver.rs
+++ b/src/webserver.rs
@@ -1,6 +1,6 @@
 use crate::{
     cfg::WebServerConfig,
-    error::{PrismResult, GeneralError},
+    error::{GeneralError, PrismResult},
     node_types::sequencer::Sequencer,
     storage::{ChainEntry, IncomingEntry},
     utils::SignedContent,
@@ -79,9 +79,10 @@ impl SignedContent for UpdateEntryJson {
             .map_err(|e| GeneralError::ParsingError(format!("signature: {}", e)).into())
     }
 
-    fn get_plaintext(&self) -> PrismResult<String> {
+    fn get_plaintext(&self) -> PrismResult<Vec<u8>> {
         serde_json::to_string(&self.incoming_entry)
             .map_err(|e| GeneralError::DecodingError(e.to_string()).into())
+            .map(|s| s.into_bytes())
     }
 
     fn get_public_key(&self) -> PrismResult<String> {

--- a/src/zk_snark.rs
+++ b/src/zk_snark.rs
@@ -247,19 +247,6 @@ mod tests {
         groth16::verify_proof(&pvk, &proof, &[]).expect("unable to verify proof")
     }
 
-    fn build_empty_tree() -> IndexedMerkleTree {
-        let empty_node = Node::new_leaf(true, Node::HEAD, Node::HEAD, Node::TAIL);
-
-        // build a tree with 4 nodes
-        IndexedMerkleTree::new(vec![
-            empty_node.clone(),
-            empty_node.clone(),
-            empty_node.clone(),
-            empty_node,
-        ])
-        .unwrap()
-    }
-
     #[test]
     fn le_with_scalar_valid() {
         let (head, small, mid, big, tail) = create_scalars();
@@ -291,7 +278,7 @@ mod tests {
 
     #[test]
     fn test_serialize_and_deserialize_proof() {
-        let mut tree = build_empty_tree();
+        let mut tree = IndexedMerkleTree::new_with_size(4).unwrap();
         let prev_commitment = tree.get_commitment().unwrap();
 
         // create two nodes to insert

--- a/src/zk_snark.rs
+++ b/src/zk_snark.rs
@@ -3,9 +3,9 @@ use crate::{
     storage::ChainEntry,
     utils::create_and_verify_snark,
 };
-use base64::{engine::general_purpose::STANDARD as engine, Engine as _};
 use bellman::{gadgets::boolean::Boolean, groth16, Circuit, ConstraintSystem, SynthesisError};
 use bls12_381::{Bls12, Scalar};
+use borsh::{BorshDeserialize, BorshSerialize};
 use ff::PrimeFieldBits;
 use indexed_merkle_tree::{
     node::{LeafNode, Node},
@@ -13,23 +13,14 @@ use indexed_merkle_tree::{
     tree::{InsertProof, MerkleProof, Proof, UpdateProof},
     Hash,
 };
-use serde::{Deserialize, Serialize};
-
-// TODO: This serialization/deserialization using JSON is not optimal - we need to minimize the amount of bytes posted on the DA layer. Let's use borsch to start.
 
 // G1Affine is a tuple alias of [`bls12_381::G1Affine`] for defining custom conversions.
 struct G1Affine(bls12_381::G1Affine);
 
-impl TryInto<G1Affine> for String {
+impl TryInto<G1Affine> for [u8; 48] {
     type Error = PrismError;
-    fn try_into(self) -> Result<G1Affine, PrismError> {
-        let decoded = engine
-            .decode(self.as_bytes())
-            .map_err(|e| PrismError::General(GeneralError::DecodingError(e.to_string())))?;
-
-        let array = vec_to_96_array(decoded)?;
-
-        match bls12_381::G1Affine::from_uncompressed(&array).into_option() {
+    fn try_into(self) -> PrismResult<G1Affine> {
+        match bls12_381::G1Affine::from_compressed(&self).into_option() {
             Some(affine) => Ok(G1Affine(affine)),
             None => Err(PrismError::General(GeneralError::DecodingError(
                 "G1Affine".to_string(),
@@ -47,16 +38,10 @@ impl From<G1Affine> for bls12_381::G1Affine {
 // G2Affine is a tuple alias of [`bls12_381::G2Affine`] for defining custom conversions.
 struct G2Affine(bls12_381::G2Affine);
 
-impl TryInto<G2Affine> for String {
+impl TryInto<G2Affine> for [u8; 96] {
     type Error = PrismError;
-    fn try_into(self) -> Result<G2Affine, PrismError> {
-        let decoded = engine
-            .decode(self.as_bytes())
-            .map_err(|e| PrismError::General(GeneralError::DecodingError(e.to_string())))?;
-
-        let array = vec_to_192_array(decoded)?;
-
-        match bls12_381::G2Affine::from_uncompressed(&array).into_option() {
+    fn try_into(self) -> PrismResult<G2Affine> {
+        match bls12_381::G2Affine::from_compressed(&self).into_option() {
             Some(affine) => Ok(G2Affine(affine)),
             None => Err(PrismError::General(GeneralError::DecodingError(
                 "G2Affine".to_string(),
@@ -71,33 +56,11 @@ impl From<G2Affine> for bls12_381::G2Affine {
     }
 }
 
-fn vec_to_96_array(vec: Vec<u8>) -> Result<[u8; 96], PrismError> {
-    let mut array = [0u8; 96];
-    if vec.len() != 96 {
-        return Err(PrismError::General(GeneralError::ParsingError(
-            "Length mismatch".to_string(),
-        )));
-    }
-    array.copy_from_slice(&vec);
-    Ok(array)
-}
-
-fn vec_to_192_array(vec: Vec<u8>) -> Result<[u8; 192], PrismError> {
-    let mut array = [0u8; 192];
-    if vec.len() != 192 {
-        return Err(PrismError::General(GeneralError::ParsingError(
-            "Length mismatch".to_string(),
-        )));
-    }
-    array.copy_from_slice(&vec);
-    Ok(array)
-}
-
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
 pub struct Bls12Proof {
-    pub a: String,
-    pub b: String,
-    pub c: String,
+    pub a: [u8; 48],
+    pub b: [u8; 96],
+    pub c: [u8; 48],
 }
 
 impl TryFrom<Bls12Proof> for groth16::Proof<Bls12> {
@@ -130,39 +93,38 @@ impl TryFrom<Bls12Proof> for groth16::Proof<Bls12> {
 impl From<groth16::Proof<Bls12>> for Bls12Proof {
     fn from(proof: groth16::Proof<Bls12>) -> Self {
         Bls12Proof {
-            a: engine.encode(proof.a.to_uncompressed().as_ref()),
-            b: engine.encode(proof.b.to_uncompressed().as_ref()),
-            c: engine.encode(proof.c.to_uncompressed().as_ref()),
+            a: proof.a.to_compressed(),
+            b: proof.b.to_compressed(),
+            c: proof.c.to_compressed(),
         }
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, BorshSerialize, BorshDeserialize, Debug)]
 pub struct VerifyingKey {
-    pub alpha_g1: String,
-    pub beta_g1: String,
-    pub beta_g2: String,
-    pub delta_g1: String,
-    pub delta_g2: String,
-    pub gamma_g2: String,
-    pub ic: String,
+    pub alpha_g1: [u8; 48],
+    pub beta_g1: [u8; 48],
+    pub beta_g2: [u8; 96],
+    pub delta_g1: [u8; 48],
+    pub delta_g2: [u8; 96],
+    pub gamma_g2: [u8; 96],
+    pub ic: Vec<[u8; 48]>,
 }
 
 impl From<groth16::VerifyingKey<Bls12>> for VerifyingKey {
     fn from(verifying_key: groth16::VerifyingKey<Bls12>) -> Self {
         VerifyingKey {
-            alpha_g1: engine.encode(verifying_key.alpha_g1.to_uncompressed().as_ref()),
-            beta_g1: engine.encode(verifying_key.beta_g1.to_uncompressed().as_ref()),
-            beta_g2: engine.encode(verifying_key.beta_g2.to_uncompressed().as_ref()),
-            delta_g1: engine.encode(verifying_key.delta_g1.to_uncompressed().as_ref()),
-            delta_g2: engine.encode(verifying_key.delta_g2.to_uncompressed().as_ref()),
-            gamma_g2: engine.encode(verifying_key.gamma_g2.to_uncompressed().as_ref()),
+            alpha_g1: verifying_key.alpha_g1.to_compressed(),
+            beta_g1: verifying_key.beta_g1.to_compressed(),
+            beta_g2: verifying_key.beta_g2.to_compressed(),
+            delta_g1: verifying_key.delta_g1.to_compressed(),
+            delta_g2: verifying_key.delta_g2.to_compressed(),
+            gamma_g2: verifying_key.gamma_g2.to_compressed(),
             ic: verifying_key
                 .ic
                 .iter()
-                .map(|x| engine.encode(x.to_uncompressed().as_ref()))
-                .collect::<Vec<String>>()
-                .join(","),
+                .map(|x| x.to_compressed())
+                .collect::<Vec<[u8; 48]>>(),
         }
     }
 }
@@ -197,8 +159,8 @@ impl TryFrom<VerifyingKey> for groth16::VerifyingKey<Bls12> {
             .map_err(|e| GeneralError::EncodingError(format!("{}: gamma_g2", e)))?;
         let ic = custom_vk
             .ic
-            .split(',')
-            .map(|s| s.to_string().try_into())
+            .into_iter()
+            .map(|s| s.try_into())
             .collect::<PrismResult<Vec<G1Affine>>>()?;
 
         Ok(bellman::groth16::VerifyingKey {
@@ -383,9 +345,9 @@ mod tests {
     #[test]
     fn test_deserialize_invalid_proof() {
         let invalid_proof = Bls12Proof {
-            a: "blubbubs".to_string(),
-            b: "FTV0oqNyecdbzY9QFPe5gfiQbSn1E0t+QHn+l+Ey6G2Dk0UZFm1wMsnRbIp5HCneDC+jf6rHCADL1NQ9FIF9o5Td8jObATCRm/YoIoeXY1yFY1rCEoJWFZU0zPeOR7XfBEmccqdMATwb8yznOj6Hn9XqZIr7E3C0XBtzk9GiahLopjP+SN9v/KLEpnLm3dn5FeAp7TcJ0gibi4nNT3u2vziKRNiDIKl71bp6tNC6grCdGOazpkrFSxiYi3QHJOYI".to_string(),
-            c: "BEKZboEyoJ3l+DLIF8IMjUR2kJQ9aq2kuXTZR8YizcQMg7zTH0xLO9JtTueneS3JFx1KlK6e2NkFZamiQERujx6bhmwIDgY8ZPCJ8iG//4E3eS0CZ25CJfnOucLeotyr".to_string(),
+            a: [1; 48],
+            b: [2; 96],
+            c: [3; 48],
         };
 
         let deserialized_proof_result: PrismResult<groth16::Proof<Bls12>> =


### PR DESCRIPTION
Not ready yet, need to release indexed-merkle-tree, and will test on a devnet.

Prev:
8192x1024 Average Insertion Time: 263.213471ms
8192x1024 Serialized Epoch Size: 2486 bytes
8192x1024: Proof Time 10.078004125s

New:
8192x1024 Average Insertion Time: 264.527932ms
8192x1024 Serialized Epoch Size: 845 bytes
8192x1024: Proof Time 10.113013042s

So the new serialized epochs are only 33% of the size