### PR TITLE
feat(tree): Return membership-proof when getting tree values

### DIFF
--- a/crates/common/src/test_utils.rs
+++ b/crates/common/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     hashchain::Hashchain,
     operation::{Operation, ServiceChallenge, SigningKey, VerifyingKey},
-    tree::{InsertProof, KeyDirectoryTree, Proof, SnarkableTree, UpdateProof},
+    tree::{HashchainResponse, InsertProof, KeyDirectoryTree, Proof, SnarkableTree, UpdateProof},
 };
 use anyhow::{anyhow, Result};
 #[cfg(not(feature = "secp256k1"))]
@@ -170,7 +170,10 @@ pub fn create_random_update(state: &mut TestTreeState, rng: &mut StdRng) -> Upda
         .iter()
         .nth(rng.gen_range(0..state.inserted_keys.len()))
         .unwrap();
-    let mut hc = state.tree.get(key).unwrap().unwrap();
+
+    let HashchainResponse::Found(mut hc, _) = state.tree.get(key).unwrap() else {
+        panic!("No response found for key. Cannot perform update.");
+    };
 
     let signing_key = create_mock_signing_key();
     let verifying_key = signing_key.verifying_key();

--- a/crates/common/src/test_utils.rs
+++ b/crates/common/src/test_utils.rs
@@ -1,7 +1,9 @@
 use crate::{
     hashchain::Hashchain,
     operation::{Operation, ServiceChallenge, SigningKey, VerifyingKey},
-    tree::{HashchainResponse, InsertProof, KeyDirectoryTree, Proof, SnarkableTree, UpdateProof},
+    tree::{
+        HashchainResponse::*, InsertProof, KeyDirectoryTree, Proof, SnarkableTree, UpdateProof,
+    },
 };
 use anyhow::{anyhow, Result};
 #[cfg(not(feature = "secp256k1"))]
@@ -171,7 +173,7 @@ pub fn create_random_update(state: &mut TestTreeState, rng: &mut StdRng) -> Upda
         .nth(rng.gen_range(0..state.inserted_keys.len()))
         .unwrap();
 
-    let HashchainResponse::Found(mut hc, _) = state.tree.get(key).unwrap() else {
+    let Found(mut hc, _) = state.tree.get(key).unwrap() else {
         panic!("No response found for key. Cannot perform update.");
     };
 

--- a/crates/common/src/tree.rs
+++ b/crates/common/src/tree.rs
@@ -188,6 +188,22 @@ pub enum Proof {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MembershipProof {
+    pub root: Digest,
+    pub proof: SparseMerkleProof<Hasher>,
+    pub key: KeyHash,
+    pub value: Hashchain,
+}
+
+impl MembershipProof {
+    pub fn verify(&self) -> Result<()> {
+        let value = bincode::serialize(&self.value)?;
+        self.proof
+            .verify_existence(self.root.into(), self.key, value)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NonMembershipProof {
     pub root: Digest,
     pub proof: SparseMerkleProof<Hasher>,

--- a/crates/common/src/tree.rs
+++ b/crates/common/src/tree.rs
@@ -284,9 +284,13 @@ impl UpdateProof {
     }
 }
 
+/// Enumerates possible responses when fetching tree values
 #[derive(Debug)]
 pub enum HashchainResponse {
+    /// When a hashchain was found, provides the value and its corresponding membership-proof
     Found(Hashchain, MembershipProof),
+
+    /// When no hashchain was found for a specific key, provides the corresponding non-membership-proof
     NotFound(NonMembershipProof),
 }
 

--- a/crates/common/src/tree.rs
+++ b/crates/common/src/tree.rs
@@ -592,10 +592,13 @@ mod tests {
         let insert_proof = tree_state.insert_account(account.clone()).unwrap();
         assert!(insert_proof.verify().is_ok());
 
-        let get_result = tree_state.tree.get(account.key_hash).unwrap();
-        assert!(
-            matches!(get_result, HashchainResponse::Found(hashchain, _) if hashchain == account.hashchain)
-        );
+        let Found(hashchain, membership_proof) = tree_state.tree.get(account.key_hash).unwrap()
+        else {
+            panic!("Expected hashchain to be found, but was not found.")
+        };
+
+        assert_eq!(hashchain, account.hashchain);
+        assert!(membership_proof.verify().is_ok());
     }
 
     #[test]

--- a/crates/common/src/tree.rs
+++ b/crates/common/src/tree.rs
@@ -551,13 +551,14 @@ where
     }
 
     fn get(&self, key: KeyHash) -> Result<HashchainResponse> {
+        let root = self.get_current_root()?.into();
         let (value, proof) = self.jmt.get_with_proof(key, self.epoch)?;
 
         match value {
             Some(serialized_value) => {
                 let deserialized_value = Self::deserialize_value(&serialized_value)?;
                 let membership_proof = MembershipProof {
-                    root: self.get_current_root()?.into(),
+                    root,
                     proof,
                     key,
                     value: deserialized_value.clone(),
@@ -565,11 +566,7 @@ where
                 Ok(Found(deserialized_value, membership_proof))
             }
             None => {
-                let non_membership_proof = NonMembershipProof {
-                    root: self.get_current_root()?.into(),
-                    proof,
-                    key,
-                };
+                let non_membership_proof = NonMembershipProof { root, proof, key };
                 Ok(NotFound(non_membership_proof))
             }
         }

--- a/crates/prism/src/node_types/sequencer.rs
+++ b/crates/prism/src/node_types/sequencer.rs
@@ -1,10 +1,9 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use async_trait::async_trait;
 use ed25519_dalek::SigningKey;
 use jmt::KeyHash;
-use prism_common::{
-    hashchain::Hashchain,
-    tree::{Batch, Digest, Hasher, KeyDirectoryTree, NonMembershipProof, Proof, SnarkableTree},
+use prism_common::tree::{
+    Batch, Digest, HashchainResponse, Hasher, KeyDirectoryTree, Proof, SnarkableTree,
 };
 use prism_errors::DataAvailabilityError;
 use std::{self, collections::VecDeque, sync::Arc};
@@ -363,10 +362,7 @@ impl Sequencer {
         tree.get_commitment().context("Failed to get commitment")
     }
 
-    pub async fn get_hashchain(
-        &self,
-        id: &String,
-    ) -> Result<Result<Hashchain, NonMembershipProof>> {
+    pub async fn get_hashchain(&self, id: &String) -> Result<HashchainResponse> {
         let tree = self.tree.read().await;
         let hashed_id = Digest::hash(id);
         let key_hash = KeyHash::with::<Hasher>(hashed_id);
@@ -393,15 +389,13 @@ impl Sequencer {
             Operation::RegisterService(_) => (),
             Operation::CreateAccount(_) => (),
             Operation::AddKey(_) | Operation::RevokeKey(_) => {
-                let hc = self.get_hashchain(&incoming_operation.id()).await?;
-                if let Ok(mut hc) = hc {
-                    hc.perform_operation(incoming_operation.clone())?;
-                } else {
-                    return Err(anyhow!(
-                        "Hashchain not found for id: {}",
-                        incoming_operation.id()
-                    ));
-                }
+                let hcr = self.get_hashchain(&incoming_operation.id()).await?;
+
+                let HashchainResponse::Found(mut hc, _) = hcr else {
+                    bail!("Hashchain not found for id: {}", incoming_operation.id())
+                };
+
+                hc.perform_operation(incoming_operation.clone())?;
             }
         };
 

--- a/crates/prism/src/node_types/sequencer.rs
+++ b/crates/prism/src/node_types/sequencer.rs
@@ -3,7 +3,8 @@ use async_trait::async_trait;
 use ed25519_dalek::SigningKey;
 use jmt::KeyHash;
 use prism_common::tree::{
-    Batch, Digest, HashchainResponse, Hasher, KeyDirectoryTree, Proof, SnarkableTree,
+    Batch, Digest, HashchainResponse, HashchainResponse::*, Hasher, KeyDirectoryTree, Proof,
+    SnarkableTree,
 };
 use prism_errors::DataAvailabilityError;
 use std::{self, collections::VecDeque, sync::Arc};
@@ -389,9 +390,9 @@ impl Sequencer {
             Operation::RegisterService(_) => (),
             Operation::CreateAccount(_) => (),
             Operation::AddKey(_) | Operation::RevokeKey(_) => {
-                let hcr = self.get_hashchain(&incoming_operation.id()).await?;
+                let hc_response = self.get_hashchain(&incoming_operation.id()).await?;
 
-                let HashchainResponse::Found(mut hc, _) = hcr else {
+                let Found(mut hc, _) = hc_response else {
                     bail!("Hashchain not found for id: {}", incoming_operation.id())
                 };
 

--- a/crates/prism/src/webserver.rs
+++ b/crates/prism/src/webserver.rs
@@ -168,7 +168,7 @@ async fn get_hashchain(
         )
             .into_response(),
         HashchainResponse::NotFound(non_membership_proof) => (
-            StatusCode::BAD_REQUEST,
+            StatusCode::OK,
             Json(UserKeyResponse {
                 hashchain: None,
                 proof: non_membership_proof.proof,

--- a/crates/prism/src/webserver.rs
+++ b/crates/prism/src/webserver.rs
@@ -11,7 +11,12 @@ use indexed_merkle_tree::{
     tree::{Proof, UpdateProof},
     Hash as TreeHash,
 };
-use prism_common::{hashchain::Hashchain, operation::Operation};
+use jmt::proof::SparseMerkleProof;
+use prism_common::{
+    hashchain::Hashchain,
+    operation::Operation,
+    tree::{HashchainResponse, Hasher},
+};
 use serde::{Deserialize, Serialize};
 use std::{self, sync::Arc};
 use tower_http::cors::CorsLayer;
@@ -46,11 +51,10 @@ pub struct UserKeyRequest {
     pub id: String,
 }
 
-// TODO: Retrieve Merkle proof of current epoch
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct UserKeyResponse {
-    pub hashchain: Hashchain,
-    // pub proof: MerkleProof
+    pub hashchain: Option<Hashchain>,
+    pub proof: SparseMerkleProof<Hasher>,
 }
 
 #[derive(OpenApi)]
@@ -142,16 +146,33 @@ async fn get_hashchain(
     State(session): State<Arc<Sequencer>>,
     Json(request): Json<UserKeyRequest>,
 ) -> impl IntoResponse {
-    match session.get_hashchain(&request.id).await {
-        Ok(hashchain_or_proof) => match hashchain_or_proof {
-            Ok(hashchain) => (StatusCode::OK, Json(UserKeyResponse { hashchain })).into_response(),
-            Err(non_inclusion_proof) => {
-                (StatusCode::BAD_REQUEST, Json(non_inclusion_proof)).into_response()
-            }
-        },
-        Err(err) => (
+    let get_hashchain_result = session.get_hashchain(&request.id).await;
+    let Ok(hashchain_response) = get_hashchain_result else {
+        return (
             StatusCode::BAD_REQUEST,
-            format!("Couldn't get hashchain: {}", err),
+            format!(
+                "Couldn't get hashchain: {}",
+                get_hashchain_result.unwrap_err()
+            ),
+        )
+            .into_response();
+    };
+
+    match hashchain_response {
+        HashchainResponse::Found(hashchain, membership_proof) => (
+            StatusCode::OK,
+            Json(UserKeyResponse {
+                hashchain: Some(hashchain),
+                proof: membership_proof.proof,
+            }),
+        )
+            .into_response(),
+        HashchainResponse::NotFound(non_membership_proof) => (
+            StatusCode::BAD_REQUEST,
+            Json(UserKeyResponse {
+                hashchain: None,
+                proof: non_membership_proof.proof,
+            }),
         )
             .into_response(),
     }

--- a/crates/prism/src/webserver.rs
+++ b/crates/prism/src/webserver.rs
@@ -149,9 +149,9 @@ async fn get_hashchain(
     let get_hashchain_result = session.get_hashchain(&request.id).await;
     let Ok(hashchain_response) = get_hashchain_result else {
         return (
-            StatusCode::BAD_REQUEST,
+            StatusCode::INTERNAL_SERVER_ERROR,
             format!(
-                "Couldn't get hashchain: {}",
+                "Failed to retrieve hashchain or non-membership-proof: {}",
                 get_hashchain_result.unwrap_err()
             ),
         )


### PR DESCRIPTION
Introduces a new response structure for hashchain retrieval, that returns the corresponding membership-proofs along with the hashchain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new response structure for hashchain retrieval, enhancing error handling and response clarity.
	- Added `MembershipProof` and `HashchainResponse` types for improved data management.
	- Updated `UserKeyResponse` to include an optional hashchain field and a new proof type.

- **Bug Fixes**
	- Streamlined error handling in various methods related to hashchain processing.

- **Documentation**
	- Updated method signatures and structures to reflect new response handling and types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->