### PR TITLE
fix(prism-prover): prover sync and config

### DIFF
--- a/crates/bin/src/cfg.rs
+++ b/crates/bin/src/cfg.rs
@@ -166,6 +166,7 @@ fn merge_configs(loaded: Config, default: Config) -> Config {
 fn apply_command_line_args(config: Config, args: CommandLineArgs) -> Config {
     Config {
         webserver: Some(WebServerConfig {
+            enabled: true,
             host: args.host.unwrap_or_else(|| {
                 config
                     .webserver

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -62,21 +62,18 @@ async fn main() -> std::io::Result<()> {
             let prover_cfg = prism_prover::Config {
                 prover: true,
                 batcher: true,
-                webserver: config.webserver.unwrap(),
+                webserver: config.webserver.unwrap_or_default(),
                 key: signing_key.clone(),
-                start_height: config.celestia_config.unwrap().start_height,
+                start_height: config.celestia_config.unwrap_or_default().start_height,
             };
 
             Arc::new(
-                Prover::new(
-                    Arc::new(Box::new(redis_connections)),
-                    da,
-                    prover_cfg.clone(),
-                )
-                .map_err(|e| {
-                    error!("error initializing prover: {}", e);
-                    std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
-                })?,
+                Prover::new(Arc::new(Box::new(redis_connections)), da, &prover_cfg).map_err(
+                    |e| {
+                        error!("error initializing prover: {}", e);
+                        std::io::Error::new(std::io::ErrorKind::Other, e.to_string())
+                    },
+                )?,
             )
         }
     };

--- a/crates/bin/src/main.rs
+++ b/crates/bin/src/main.rs
@@ -59,13 +59,19 @@ async fn main() -> std::io::Result<()> {
                 .get_signing_key()
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))?;
 
+            let prover_cfg = prism_prover::Config {
+                prover: true,
+                batcher: true,
+                webserver: config.webserver.unwrap(),
+                key: signing_key.clone(),
+                start_height: config.celestia_config.unwrap().start_height,
+            };
+
             Arc::new(
                 Prover::new(
                     Arc::new(Box::new(redis_connections)),
                     da,
-                    config.webserver.unwrap(),
-                    config.celestia_config.unwrap().start_height,
-                    signing_key,
+                    prover_cfg.clone(),
                 )
                 .map_err(|e| {
                     error!("error initializing prover: {}", e);

--- a/crates/common/src/tree.rs
+++ b/crates/common/src/tree.rs
@@ -332,6 +332,18 @@ where
         tree
     }
 
+    pub fn load(store: Arc<S>, epoch: u64) -> Self {
+        if epoch == 0 {
+            return KeyDirectoryTree::new(store);
+        }
+        Self {
+            db: store.clone(),
+            jmt: JellyfishMerkleTree::<Arc<S>, Hasher>::new(store),
+            pending_batch: None,
+            epoch,
+        }
+    }
+
     pub fn get_commitment(&self) -> Result<Digest> {
         let root = self.get_current_root()?;
         Ok(Digest(root.0))

--- a/crates/da/src/celestia.rs
+++ b/crates/da/src/celestia.rs
@@ -176,7 +176,7 @@ impl DataAvailabilityLayer for CelestiaConnection {
                 .map_err(|e| {
                     anyhow!(DataAvailabilityError::DataRetrievalError(
                         height,
-                        e.to_string()
+                        format!("getting operations from da layer: {}", e)
                     ))
                 })?;
 

--- a/crates/node_types/prover/src/lib.rs
+++ b/crates/node_types/prover/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod prover;
 pub mod webserver;
 
-pub use prover::Prover;
+pub use prover::{Config, Prover};
 
 #[macro_use]
 extern crate log;
+
+#[cfg(test)]
+mod tests;

--- a/crates/node_types/prover/src/lib.rs
+++ b/crates/node_types/prover/src/lib.rs
@@ -5,6 +5,3 @@ pub use prover::{Config, Prover};
 
 #[macro_use]
 extern crate log;
-
-#[cfg(test)]
-mod tests;

--- a/crates/node_types/prover/src/prover.rs
+++ b/crates/node_types/prover/src/prover.rs
@@ -1,13 +1,17 @@
 use anyhow::{anyhow, bail, Context, Result};
 use ed25519_consensus::SigningKey;
 use jmt::KeyHash;
+use keystore_rs::create_signing_key;
 use prism_common::tree::{
     Batch, Digest, HashchainResponse, HashchainResponse::*, Hasher, KeyDirectoryTree, Proof,
     SnarkableTree,
 };
 use prism_errors::DataAvailabilityError;
 use std::{self, collections::VecDeque, sync::Arc};
-use tokio::sync::{broadcast, RwLock};
+use tokio::{
+    sync::{broadcast, RwLock},
+    task::JoinSet,
+};
 
 use crate::webserver::{WebServer, WebServerConfig};
 use prism_common::operation::Operation;
@@ -17,23 +21,54 @@ use sp1_sdk::{ProverClient, SP1ProvingKey, SP1Stdin, SP1VerifyingKey};
 
 pub const PRISM_ELF: &[u8] = include_bytes!("../../../../elf/riscv32im-succinct-zkvm-elf");
 
+#[derive(Clone)]
+pub struct Config {
+    /// Enables generating FinalizedEpochs and posting them to the DA
+    /// layer. When deactivated, the node will simply sync historical and
+    /// incoming FinalizedEpochs.
+    pub prover: bool,
+
+    /// Enables accepting incoming operations from the webserver and posting batches to the DA layer.
+    /// When deactivated, the node will reject incoming operations.
+    pub batcher: bool,
+
+    /// Configuration for the webserver.
+    pub webserver: WebServerConfig,
+
+    /// Key used to sign new FinalizedEpochs.
+    pub key: SigningKey,
+
+    /// DA layer height the prover should start syncing operations from.
+    pub start_height: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            prover: true,
+            batcher: true,
+            webserver: WebServerConfig::default(),
+            key: create_signing_key(),
+            start_height: 1,
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub struct Prover {
     pub db: Arc<dyn Database>,
     pub da: Arc<dyn DataAvailabilityLayer>,
-    pub ws: WebServer,
 
-    // [`start_height`] is the DA layer height the prover should start syncing operations from.
-    pub start_height: u64,
+    pub cfg: Config,
 
-    pub key: SigningKey,
+    /// [`pending_operations`] is a buffer for operations that have not yet been
+    /// posted to the DA layer.
+    pub(crate) pending_operations: Arc<RwLock<Vec<Operation>>>,
 
-    // [`pending_operations`] is a buffer for operations that have not yet been
-    // posted to the DA layer.
-    pending_operations: Arc<RwLock<Vec<Operation>>>,
+    /// [`tree`] is the representation of the JMT, prism's state tree. It is accessed via the [`db`].
     tree: Arc<RwLock<KeyDirectoryTree<Box<dyn Database>>>>,
-    prover_client: Arc<RwLock<ProverClient>>,
 
+    prover_client: Arc<RwLock<ProverClient>>,
     proving_key: SP1ProvingKey,
     verifying_key: SP1VerifyingKey,
 }
@@ -43,9 +78,7 @@ impl Prover {
     pub fn new(
         db: Arc<Box<dyn Database>>,
         da: Arc<dyn DataAvailabilityLayer>,
-        cfg: WebServerConfig,
-        start_height: u64,
-        key: SigningKey,
+        cfg: Config,
     ) -> Result<Prover> {
         let tree = Arc::new(RwLock::new(KeyDirectoryTree::new(db.clone())));
 
@@ -59,11 +92,9 @@ impl Prover {
         Ok(Prover {
             db: db.clone(),
             da,
-            ws: WebServer::new(cfg),
+            cfg: cfg.clone(),
             proving_key: pk,
             verifying_key: vk,
-            key,
-            start_height,
             prover_client: Arc::new(RwLock::new(prover_client)),
             tree,
             pending_operations: Arc::new(RwLock::new(Vec::new())),
@@ -78,29 +109,53 @@ impl Prover {
             .context("Failed to start DataAvailabilityLayer")?;
 
         let main_loop = self.clone().main_loop();
-        let batch_poster = self.clone().post_batch_loop();
 
-        let ws_self = self.clone();
-        let ws = ws_self.ws.start(self.clone());
+        let mut futures = JoinSet::new();
+        futures.spawn(main_loop);
 
-        tokio::select! {
-            res = main_loop => Ok(res.context("main loop failed")?),
-            res = batch_poster => Ok(res.context("batch poster failed")?),
-            res = ws => Ok(res.context("WebServer failed")?),
+        if self.cfg.batcher {
+            let batch_poster = self.clone().post_batch_loop();
+            futures.spawn(batch_poster);
         }
+
+        let ws = WebServer::new(self.cfg.webserver.clone(), self.clone());
+        if self.cfg.webserver.enabled {
+            futures.spawn(async move { ws.start().await });
+        }
+
+        if let Some(result) = futures.join_next().await {
+            error!("Service exited unexpectedly: {:?}", result);
+            Err(anyhow!("Service exited unexpectedly"))?
+        }
+        error!("All services have ended unexpectedly.");
+        Err(anyhow!("All services have ended unexpectedly"))?
     }
+
     async fn main_loop(self: Arc<Self>) -> Result<()> {
         let mut height_rx = self.da.subscribe_to_heights();
         let current_height = height_rx.recv().await?;
-        let historical_sync_height = current_height - 1;
+        let historical_sync_height = current_height;
 
-        self.sync_range(self.start_height, historical_sync_height)
-            .await?;
-        self.real_time_sync(height_rx).await
+        let start_height = match self.db.get_last_synced_height() {
+            Ok(height) => height,
+            Err(_) => {
+                debug!("no existing sync height found, setting sync height to start_height");
+                self.db.set_last_synced_height(&self.cfg.start_height)?;
+                self.cfg.start_height
+            }
+        };
+
+        self.sync_loop(start_height, historical_sync_height, height_rx)
+            .await
     }
 
-    async fn sync_range(&self, start_height: u64, end_height: u64) -> Result<()> {
-        let mut saved_epoch = match self.db.get_epoch() {
+    async fn sync_loop(
+        &self,
+        start_height: u64,
+        end_height: u64,
+        mut incoming_heights: broadcast::Receiver<u64>,
+    ) -> Result<()> {
+        let saved_epoch = match self.db.get_epoch() {
             Ok(epoch) => epoch,
             Err(_) => {
                 debug!("no existing epoch state found, setting epoch to 0");
@@ -108,23 +163,22 @@ impl Prover {
                 0
             }
         };
+
+        // TODO: There is probably a better place to put this? Maybe on database initialization
+        if saved_epoch == 0 {
+            let initial_commitment = self.get_commitment().await?;
+            self.db.set_commitment(&0, &initial_commitment)?;
+        }
+
+        // TODO: Should be persisted in database for crash recovery
         let mut buffered_operations: VecDeque<Vec<Operation>> = VecDeque::new();
         let mut current_height = start_height;
 
-        while current_height < end_height {
-            let height = current_height + 1;
-            let operations = self.da.get_operations(height).await?;
-            let epoch_result = self.da.get_finalized_epoch(height).await?;
-
-            self.sync_historical_epoch(
-                height,
-                operations,
-                epoch_result,
-                &mut saved_epoch,
-                &mut buffered_operations,
-            )
-            .await?;
-
+        while current_height <= end_height {
+            self.process_height(current_height, &mut buffered_operations, false)
+                .await?;
+            // TODO: Race between set_epoch and set_last_synced_height
+            self.db.set_last_synced_height(&current_height)?;
             current_height += 1;
         }
 
@@ -132,7 +186,192 @@ impl Prover {
             "finished historical sync from height {} to {}",
             start_height, end_height
         );
+
+        loop {
+            let height = incoming_heights.recv().await?;
+            assert_eq!(height, current_height, "heights should be sequential");
+            self.process_height(height, &mut buffered_operations, true)
+                .await?;
+            current_height += 1;
+            // TODO: Race between set_epoch and set_last_synced_height
+            self.db.set_last_synced_height(&current_height)?;
+        }
+    }
+
+    async fn process_height(
+        &self,
+        height: u64,
+        buffered_operations: &mut VecDeque<Vec<Operation>>,
+        is_real_time: bool,
+    ) -> Result<()> {
+        let current_epoch = self.db.get_epoch()?;
+
+        let operations = self.da.get_operations(height).await?;
+        let epoch_result = self.da.get_finalized_epoch(height).await?;
+
+        debug!(
+            "processing {} height {}, current_epoch: {}",
+            if is_real_time { "new" } else { "old" },
+            height,
+            current_epoch
+        );
+
+        if let Some(epoch) = epoch_result {
+            // run all buffered operations from the last celestia blocks and increment current_epoch
+            self.process_existing_epoch(epoch, buffered_operations)
+                .await?;
+        } else {
+            debug!("No operations to process at height {}", height);
+        }
+
+        if is_real_time && !buffered_operations.is_empty() && self.cfg.prover {
+            let all_ops: Vec<Operation> = buffered_operations.drain(..).flatten().collect();
+            self.finalize_new_epoch(current_epoch, all_ops).await?;
+        }
+
+        // If there are new operations at this height, add them to the queue to
+        // be included in the next finalized epoch.
+        if !operations.is_empty() {
+            buffered_operations.push_back(operations);
+        }
+
         Ok(())
+    }
+
+    async fn process_existing_epoch(
+        &self,
+        epoch: FinalizedEpoch,
+        buffered_operations: &mut VecDeque<Vec<Operation>>,
+    ) -> Result<()> {
+        let mut current_epoch = self.db.get_epoch()?;
+        if epoch.height < current_epoch {
+            debug!("epoch {} already processed internally", current_epoch);
+            return Ok(());
+        }
+
+        let prev_commitment = self.db.get_commitment(&current_epoch)?;
+
+        if epoch.height != current_epoch {
+            return Err(anyhow!(
+                "epoch height mismatch: expected {}, got {}",
+                current_epoch,
+                epoch.height
+            ));
+        }
+
+        if epoch.prev_commitment != prev_commitment {
+            return Err(anyhow!(
+                "previous commitment mismatch at epoch {}",
+                current_epoch
+            ));
+        }
+
+        while let Some(buffered_ops) = buffered_operations.pop_front() {
+            self.execute_block(buffered_ops).await?;
+        }
+
+        let new_commitment = self.get_commitment().await?;
+        if epoch.current_commitment != new_commitment {
+            return Err(anyhow!(
+                "new commitment mismatch at epoch {}",
+                current_epoch
+            ));
+        }
+
+        debug!(
+            "processed epoch {}. new commitment: {:?}",
+            current_epoch, new_commitment
+        );
+
+        current_epoch += 1;
+        self.db.set_commitment(&current_epoch, &new_commitment)?;
+        self.db.set_epoch(&current_epoch)?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn execute_block(&self, operations: Vec<Operation>) -> Result<Vec<Proof>> {
+        debug!("executing block with {} operations", operations.len());
+
+        let mut proofs = Vec::new();
+
+        for operation in operations {
+            match self.process_operation(&operation).await {
+                Ok(proof) => proofs.push(proof),
+                Err(e) => {
+                    // Log the error and continue with the next operation
+                    warn!("Failed to process operation: {:?}. Error: {}", operation, e);
+                }
+            }
+        }
+
+        Ok(proofs)
+    }
+
+    pub(crate) async fn finalize_new_epoch(
+        &self,
+        epoch_height: u64,
+        operations: Vec<Operation>,
+    ) -> Result<()> {
+        let prev_commitment = self.get_commitment().await?;
+
+        let proofs = self.execute_block(operations).await?;
+
+        let new_commitment = self.get_commitment().await?;
+
+        let finalized_epoch = self
+            .prove_epoch(epoch_height, prev_commitment, new_commitment, proofs)
+            .await?;
+
+        self.da.submit_finalized_epoch(finalized_epoch).await?;
+
+        let new_epoch_height = epoch_height + 1;
+        self.db.set_commitment(&new_epoch_height, &new_commitment)?;
+        self.db.set_epoch(&new_epoch_height)?;
+
+        info!("finalized new epoch at height {}", epoch_height);
+
+        Ok(())
+    }
+
+    pub(crate) async fn prove_epoch(
+        &self,
+        epoch_height: u64,
+        prev_commitment: Digest,
+        new_commitment: Digest,
+        proofs: Vec<Proof>,
+    ) -> Result<FinalizedEpoch> {
+        let batch = Batch {
+            prev_root: prev_commitment,
+            new_root: new_commitment,
+            proofs,
+        };
+
+        let mut stdin = SP1Stdin::new();
+        stdin.write(&batch);
+        let client = self.prover_client.read().await;
+
+        info!("generating proof for epoch at height {}", epoch_height);
+        #[cfg(not(feature = "groth16"))]
+        let proof = client.prove(&self.proving_key, stdin).run()?;
+
+        #[cfg(feature = "groth16")]
+        let proof = client.prove(&self.proving_key, stdin).groth16().run()?;
+        info!("successfully generated proof for epoch {}", epoch_height);
+
+        client.verify(&proof, &self.verifying_key)?;
+        info!("verified proof for epoch {}", epoch_height);
+
+        let mut epoch_json = FinalizedEpoch {
+            height: epoch_height,
+            prev_commitment,
+            current_commitment: new_commitment,
+            proof,
+            signature: None,
+        };
+
+        epoch_json.insert_signature(&self.cfg.key);
+        Ok(epoch_json)
     }
 
     async fn post_batch_loop(self: Arc<Self>) -> Result<()> {
@@ -172,212 +411,6 @@ impl Prover {
         }
     }
 
-    async fn real_time_sync(&self, mut height_rx: broadcast::Receiver<u64>) -> Result<()> {
-        let saved_epoch = self.db.get_epoch()?;
-        let mut current_epoch: u64 = saved_epoch;
-        let mut buffered_operations: VecDeque<Vec<Operation>> = VecDeque::new();
-
-        loop {
-            let height = height_rx.recv().await?;
-            let operations = self.da.get_operations(height).await?;
-
-            self.process_real_time_epoch(
-                height,
-                operations,
-                &mut current_epoch,
-                &mut buffered_operations,
-            )
-            .await?;
-        }
-    }
-
-    async fn sync_historical_epoch(
-        &self,
-        height: u64,
-        operations: Vec<Operation>,
-        epoch_result: Option<FinalizedEpoch>,
-        current_epoch: &mut u64,
-        buffered_operations: &mut VecDeque<Vec<Operation>>,
-    ) -> Result<()> {
-        let prev_commitment = self.get_commitment().await?;
-
-        debug!(
-            "processing old height {}, current_epoch: {}",
-            height, current_epoch
-        );
-
-        // If there are new operations at this height, add them to the queue to
-        // be included in the next finalized epoch.
-        if !operations.is_empty() {
-            buffered_operations.push_back(operations);
-        }
-
-        if let Some(epoch) = epoch_result {
-            // run all buffered operations from the last celestia blocks and increment current_epoch
-            self.process_existing_epoch(
-                epoch,
-                current_epoch,
-                buffered_operations,
-                prev_commitment,
-                height,
-            )
-            .await?;
-        } else {
-            debug!("No operations to process at height {}", height);
-        }
-
-        Ok(())
-    }
-
-    async fn process_real_time_epoch(
-        &self,
-        height: u64,
-        operations: Vec<Operation>,
-        current_epoch: &mut u64,
-        buffered_operations: &mut VecDeque<Vec<Operation>>,
-    ) -> Result<()> {
-        debug!(
-            "processing new height {}, current_epoch: {}",
-            height, current_epoch
-        );
-
-        // If there are new operations at this height, add them to the queue to
-        // be included in the next finalized epoch.
-        if !operations.is_empty() {
-            buffered_operations.push_back(operations);
-        }
-
-        if !buffered_operations.is_empty() {
-            let all_ops: Vec<Operation> = buffered_operations.drain(..).flatten().collect();
-            self.finalize_new_epoch(*current_epoch, all_ops).await?;
-            *current_epoch += 1;
-        }
-
-        Ok(())
-    }
-
-    async fn process_existing_epoch(
-        &self,
-        epoch: FinalizedEpoch,
-        current_epoch: &mut u64,
-        buffered_operations: &mut VecDeque<Vec<Operation>>,
-        prev_commitment: Digest,
-        height: u64,
-    ) -> Result<()> {
-        if epoch.height != *current_epoch {
-            return Err(anyhow!(
-                "Epoch height mismatch: expected {}, got {}",
-                current_epoch,
-                epoch.height
-            ));
-        }
-        if epoch.prev_commitment != prev_commitment {
-            return Err(anyhow!("Commitment mismatch at epoch {}", current_epoch));
-        }
-
-        while let Some(buffered_ops) = buffered_operations.pop_front() {
-            self.execute_block(buffered_ops).await?;
-        }
-
-        let new_commitment = self.get_commitment().await?;
-        if epoch.current_commitment != new_commitment {
-            return Err(anyhow!("Commitment mismatch at epoch {}", current_epoch));
-        }
-
-        debug!(
-            "Processed height {}. New commitment: {:?}",
-            height, new_commitment
-        );
-        *current_epoch += 1;
-        Ok(())
-    }
-
-    async fn execute_block(&self, operations: Vec<Operation>) -> Result<Vec<Proof>> {
-        debug!("executing block with {} operations", operations.len());
-
-        let mut proofs = Vec::new();
-
-        for operation in operations {
-            match self.process_operation(&operation).await {
-                Ok(proof) => proofs.push(proof),
-                Err(e) => {
-                    // Log the error and continue with the next operation
-                    warn!("Failed to process operation: {:?}. Error: {}", operation, e);
-                }
-            }
-        }
-
-        Ok(proofs)
-    }
-
-    async fn finalize_new_epoch(
-        &self,
-        epoch_height: u64,
-        operations: Vec<Operation>,
-    ) -> Result<()> {
-        let prev_commitment = self.get_commitment().await?;
-
-        let proofs = self.execute_block(operations).await?;
-
-        let new_commitment = self.get_commitment().await?;
-
-        let finalized_epoch = self
-            .prove_epoch(epoch_height, prev_commitment, new_commitment, proofs)
-            .await?;
-
-        self.da.submit_finalized_epoch(finalized_epoch).await?;
-
-        self.db.set_commitment(&epoch_height, &new_commitment)?;
-        self.db.set_epoch(&epoch_height)?;
-
-        info!("Finalized new epoch at height {}", epoch_height);
-
-        Ok(())
-    }
-
-    async fn prove_epoch(
-        &self,
-        height: u64,
-        prev_commitment: Digest,
-        new_commitment: Digest,
-        proofs: Vec<Proof>,
-    ) -> Result<FinalizedEpoch> {
-        let batch = Batch {
-            prev_root: prev_commitment,
-            new_root: new_commitment,
-            proofs,
-        };
-
-        let mut stdin = SP1Stdin::new();
-        stdin.write(&batch);
-        let client = self.prover_client.read().await;
-
-        info!("generating proof for epoch at height {}", height);
-        #[cfg(not(feature = "groth16"))]
-        let proof = client.prove(&self.proving_key, stdin).run()?;
-
-        #[cfg(feature = "groth16")]
-        let proof = client.prove(&self.proving_key, stdin).groth16().run()?;
-        info!(
-            "successfully generated proof for epoch at height {}",
-            height
-        );
-
-        client.verify(&proof, &self.verifying_key)?;
-        info!("verified proof for epoch height {}", height);
-
-        let mut epoch_json = FinalizedEpoch {
-            height,
-            prev_commitment,
-            current_commitment: new_commitment,
-            proof,
-            signature: None,
-        };
-
-        epoch_json.insert_signature(&self.key);
-        Ok(epoch_json)
-    }
-
     pub async fn get_commitment(&self) -> Result<Digest> {
         let tree = self.tree.read().await;
         tree.get_commitment().context("Failed to get commitment")
@@ -392,7 +425,7 @@ impl Prover {
     }
 
     /// Updates the state from an already verified pending operation.
-    async fn process_operation(&self, operation: &Operation) -> Result<Proof> {
+    pub(crate) async fn process_operation(&self, operation: &Operation) -> Result<Proof> {
         let mut tree = self.tree.write().await;
         tree.process_operation(operation)
     }
@@ -402,6 +435,10 @@ impl Prover {
         self: Arc<Self>,
         incoming_operation: &Operation,
     ) -> Result<()> {
+        if !self.cfg.batcher {
+            bail!("Batcher is disabled, cannot queue operations");
+        }
+
         // basic validation, does not include signature checks
         incoming_operation.validate()?;
 
@@ -423,203 +460,5 @@ impl Prover {
         let mut pending = self.pending_operations.write().await;
         pending.push(incoming_operation.clone());
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use keystore_rs::create_signing_key;
-    use prism_common::test_utils::create_mock_signing_key;
-    use prism_da::memory::InMemoryDataAvailabilityLayer;
-    use prism_storage::inmemory::InMemoryDatabase;
-
-    // Helper function to create a test prover instance
-    async fn create_test_prover() -> Arc<Prover> {
-        let (da_layer, _rx, _brx) = InMemoryDataAvailabilityLayer::new(1);
-        let da_layer = Arc::new(da_layer);
-        let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
-        let signing_key = create_signing_key();
-        let cfg = WebServerConfig::default();
-        Arc::new(Prover::new(db.clone(), da_layer, cfg, 0, signing_key.clone()).unwrap())
-    }
-
-    #[tokio::test]
-    async fn test_validate_and_queue_update() {
-        let prover = create_test_prover().await;
-
-        let service_key = create_mock_signing_key();
-        let op =
-            Operation::new_register_service("service_id".to_string(), service_key.clone().into());
-
-        prover.clone().validate_and_queue_update(&op).await.unwrap();
-
-        prover.clone().validate_and_queue_update(&op).await.unwrap();
-
-        let pending_ops = prover.pending_operations.read().await;
-        assert_eq!(pending_ops.len(), 2);
-    }
-
-    #[tokio::test]
-    async fn test_process_operation() {
-        let prover = create_test_prover().await;
-
-        let signing_key = create_mock_signing_key();
-        let original_pubkey = signing_key.verifying_key();
-        let service_key = create_mock_signing_key();
-
-        let register_service_op =
-            Operation::new_register_service("service_id".to_string(), service_key.clone().into());
-        let create_account_op = Operation::new_create_account(
-            "test@example.com".to_string(),
-            &signing_key,
-            "service_id".to_string(),
-            &service_key,
-        )
-        .unwrap();
-
-        let proof = prover
-            .process_operation(&register_service_op)
-            .await
-            .unwrap();
-        assert!(matches!(proof, Proof::Insert(_)));
-
-        let proof = prover.process_operation(&create_account_op).await.unwrap();
-        assert!(matches!(proof, Proof::Insert(_)));
-
-        let new_key = create_mock_signing_key();
-        let pubkey = new_key.verifying_key();
-        let add_key_op =
-            Operation::new_add_key("test@example.com".to_string(), pubkey, &signing_key, 0)
-                .unwrap();
-
-        let proof = prover.process_operation(&add_key_op).await.unwrap();
-
-        assert!(matches!(proof, Proof::Update(_)));
-
-        // Revoke original key
-        let revoke_op =
-            Operation::new_revoke_key("test@example.com".to_string(), original_pubkey, &new_key, 1)
-                .unwrap();
-        let proof = prover.process_operation(&revoke_op).await.unwrap();
-        assert!(matches!(proof, Proof::Update(_)));
-    }
-
-    #[tokio::test]
-    async fn test_execute_block_with_invalid_tx() {
-        let prover = create_test_prover().await;
-
-        let signing_key_1 = create_mock_signing_key();
-        let signing_key_2 = create_mock_signing_key();
-        let signing_key_3 = create_mock_signing_key();
-        let service_key = create_mock_signing_key();
-
-        let operations = vec![
-            Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
-            Operation::new_create_account(
-                "user1@example.com".to_string(),
-                &signing_key_1,
-                "service_id".to_string(),
-                &service_key,
-            )
-            .unwrap(),
-            // add signing_key_2, so it will be index = 1
-            Operation::new_add_key(
-                "user1@example.com".to_string(),
-                signing_key_2.verifying_key(),
-                &signing_key_1,
-                0,
-            )
-            .unwrap(),
-            // try revoking signing_key_2
-            Operation::new_revoke_key(
-                "user1@example.com".to_string(),
-                signing_key_2.verifying_key(),
-                &signing_key_1,
-                0,
-            )
-            .unwrap(),
-            // and adding in same block.
-            // both of these operations are valid individually, but when processed together it will fail.
-            Operation::new_add_key(
-                "user1@example.com".to_string(),
-                signing_key_3.verifying_key(),
-                &signing_key_2,
-                1,
-            )
-            .unwrap(),
-        ];
-
-        let proofs = prover.execute_block(operations).await.unwrap();
-        assert_eq!(proofs.len(), 4);
-    }
-
-    #[tokio::test]
-    async fn test_execute_block() {
-        let prover = create_test_prover().await;
-
-        let signing_key_1 = create_mock_signing_key();
-        let signing_key_2 = create_mock_signing_key();
-        let new_key = create_mock_signing_key().verifying_key();
-        let service_key = create_mock_signing_key();
-
-        let operations = vec![
-            Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
-            Operation::new_create_account(
-                "user1@example.com".to_string(),
-                &signing_key_1,
-                "service_id".to_string(),
-                &service_key,
-            )
-            .unwrap(),
-            Operation::new_create_account(
-                "user2@example.com".to_string(),
-                &signing_key_2,
-                "service_id".to_string(),
-                &service_key,
-            )
-            .unwrap(),
-            Operation::new_add_key("user1@example.com".to_string(), new_key, &signing_key_1, 0)
-                .unwrap(),
-        ];
-
-        let proofs = prover.execute_block(operations).await.unwrap();
-        assert_eq!(proofs.len(), 4);
-    }
-
-    #[tokio::test]
-    async fn test_finalize_new_epoch() {
-        let prover = create_test_prover().await;
-
-        let signing_key_1 = create_mock_signing_key();
-        let signing_key_2 = create_mock_signing_key();
-        let new_key = create_mock_signing_key().verifying_key();
-        let service_key = create_mock_signing_key();
-
-        let operations = vec![
-            Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
-            Operation::new_create_account(
-                "user1@example.com".to_string(),
-                &signing_key_1,
-                "service_id".to_string(),
-                &service_key,
-            )
-            .unwrap(),
-            Operation::new_create_account(
-                "user2@example.com".to_string(),
-                &signing_key_2,
-                "service_id".to_string(),
-                &service_key,
-            )
-            .unwrap(),
-            Operation::new_add_key("user1@example.com".to_string(), new_key, &signing_key_1, 0)
-                .unwrap(),
-        ];
-
-        let prev_commitment = prover.get_commitment().await.unwrap();
-        prover.finalize_new_epoch(0, operations).await.unwrap();
-
-        let new_commitment = prover.get_commitment().await.unwrap();
-        assert_ne!(prev_commitment, new_commitment);
     }
 }

--- a/crates/node_types/prover/src/prover/mod.rs
+++ b/crates/node_types/prover/src/prover/mod.rs
@@ -78,7 +78,7 @@ impl Prover {
     pub fn new(
         db: Arc<Box<dyn Database>>,
         da: Arc<dyn DataAvailabilityLayer>,
-        cfg: Config,
+        cfg: &Config,
     ) -> Result<Prover> {
         let tree = Arc::new(RwLock::new(KeyDirectoryTree::new(db.clone())));
 

--- a/crates/node_types/prover/src/prover/mod.rs
+++ b/crates/node_types/prover/src/prover/mod.rs
@@ -187,7 +187,13 @@ impl Prover {
 
         loop {
             let height = incoming_heights.recv().await?;
-            assert_eq!(height, current_height, "heights should be sequential");
+            if height != current_height {
+                return Err(anyhow!(
+                    "heights are not sequential: expected {}, got {}",
+                    current_height,
+                    height
+                ));
+            }
             self.process_da_height(height, &mut buffered_operations, true)
                 .await?;
             current_height += 1;

--- a/crates/node_types/prover/src/prover/mod.rs
+++ b/crates/node_types/prover/src/prover/mod.rs
@@ -19,7 +19,7 @@ use prism_da::{DataAvailabilityLayer, FinalizedEpoch};
 use prism_storage::Database;
 use sp1_sdk::{ProverClient, SP1ProvingKey, SP1Stdin, SP1VerifyingKey};
 
-pub const PRISM_ELF: &[u8] = include_bytes!("../../../../elf/riscv32im-succinct-zkvm-elf");
+pub const PRISM_ELF: &[u8] = include_bytes!("../../../../../elf/riscv32im-succinct-zkvm-elf");
 
 #[derive(Clone)]
 pub struct Config {
@@ -63,7 +63,7 @@ pub struct Prover {
 
     /// [`pending_operations`] is a buffer for operations that have not yet been
     /// posted to the DA layer.
-    pub(crate) pending_operations: Arc<RwLock<Vec<Operation>>>,
+    pub pending_operations: Arc<RwLock<Vec<Operation>>>,
 
     /// [`tree`] is the representation of the JMT, prism's state tree. It is accessed via the [`db`].
     tree: Arc<RwLock<KeyDirectoryTree<Box<dyn Database>>>>,
@@ -292,7 +292,7 @@ impl Prover {
         Ok(())
     }
 
-    pub(crate) async fn execute_block(&self, operations: Vec<Operation>) -> Result<Vec<Proof>> {
+    async fn execute_block(&self, operations: Vec<Operation>) -> Result<Vec<Proof>> {
         debug!("executing block with {} operations", operations.len());
 
         let mut proofs = Vec::new();
@@ -310,7 +310,7 @@ impl Prover {
         Ok(proofs)
     }
 
-    pub(crate) async fn finalize_new_epoch(
+    async fn finalize_new_epoch(
         &self,
         epoch_height: u64,
         operations: Vec<Operation>,
@@ -336,7 +336,7 @@ impl Prover {
         Ok(())
     }
 
-    pub(crate) async fn prove_epoch(
+    async fn prove_epoch(
         &self,
         epoch_height: u64,
         prev_commitment: Digest,
@@ -427,7 +427,7 @@ impl Prover {
     }
 
     /// Updates the state from an already verified pending operation.
-    pub(crate) async fn process_operation(&self, operation: &Operation) -> Result<Proof> {
+    async fn process_operation(&self, operation: &Operation) -> Result<Proof> {
         let mut tree = self.tree.write().await;
         tree.process_operation(operation)
     }
@@ -464,3 +464,6 @@ impl Prover {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -50,7 +50,6 @@ async fn test_validate_and_queue_update() {
     let op = Operation::new_register_service("service_id".to_string(), service_key.clone().into());
 
     prover.clone().validate_and_queue_update(&op).await.unwrap();
-
     prover.clone().validate_and_queue_update(&op).await.unwrap();
 
     let pending_ops = prover.pending_operations.read().await;

--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -1,8 +1,8 @@
+use super::*;
 use prism_common::tree::Proof;
 use std::{self, sync::Arc, time::Duration};
 use tokio::spawn;
 
-use crate::{Config, Prover};
 use prism_common::{operation::Operation, test_utils::create_mock_signing_key};
 use prism_da::memory::InMemoryDataAvailabilityLayer;
 use prism_storage::{inmemory::InMemoryDatabase, Database};

--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -13,7 +13,7 @@ async fn create_test_prover() -> Arc<Prover> {
     let da_layer = Arc::new(da_layer);
     let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let cfg = Config::default();
-    Arc::new(Prover::new(db.clone(), da_layer, cfg.clone()).unwrap())
+    Arc::new(Prover::new(db.clone(), da_layer, &cfg).unwrap())
 }
 
 fn create_mock_operations(service_id: String) -> Vec<Operation> {
@@ -179,7 +179,7 @@ async fn test_restart_sync_from_scratch() {
     let db1: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let db2: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let cfg = Config::default();
-    let prover = Arc::new(Prover::new(db1.clone(), da_layer.clone(), cfg.clone()).unwrap());
+    let prover = Arc::new(Prover::new(db1.clone(), da_layer.clone(), &cfg).unwrap());
 
     let runner = prover.clone();
     spawn(async move {
@@ -199,7 +199,7 @@ async fn test_restart_sync_from_scratch() {
 
     assert_eq!(prover.clone().db.get_epoch().unwrap(), 4);
 
-    let prover2 = Arc::new(Prover::new(db2.clone(), da_layer.clone(), cfg.clone()).unwrap());
+    let prover2 = Arc::new(Prover::new(db2.clone(), da_layer.clone(), &cfg).unwrap());
     let runner = prover2.clone();
     spawn(async move { runner.run().await.unwrap() });
 
@@ -208,7 +208,7 @@ async fn test_restart_sync_from_scratch() {
         if epoch == 4 {
             break;
         }
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_millis(200)).await;
     }
 }
 
@@ -218,7 +218,7 @@ async fn test_load_persisted_state() {
     let da_layer = Arc::new(da_layer);
     let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let cfg = Config::default();
-    let prover = Arc::new(Prover::new(db.clone(), da_layer.clone(), cfg.clone()).unwrap());
+    let prover = Arc::new(Prover::new(db.clone(), da_layer.clone(), &cfg).unwrap());
 
     let runner = prover.clone();
     spawn(async move {
@@ -238,7 +238,7 @@ async fn test_load_persisted_state() {
 
     assert_eq!(prover.clone().db.get_epoch().unwrap(), 4);
 
-    let prover2 = Arc::new(Prover::new(db.clone(), da_layer.clone(), cfg.clone()).unwrap());
+    let prover2 = Arc::new(Prover::new(db.clone(), da_layer.clone(), &cfg).unwrap());
     let runner = prover2.clone();
     spawn(async move { runner.run().await.unwrap() });
     let epoch = prover2.clone().db.get_epoch().unwrap();

--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -50,6 +50,7 @@ async fn test_validate_and_queue_update() {
     let op = Operation::new_register_service("service_id".to_string(), service_key.clone().into());
 
     prover.clone().validate_and_queue_update(&op).await.unwrap();
+
     prover.clone().validate_and_queue_update(&op).await.unwrap();
 
     let pending_ops = prover.pending_operations.read().await;
@@ -205,6 +206,10 @@ async fn test_restart_sync_from_scratch() {
     loop {
         let epoch = prover2.clone().db.get_epoch().unwrap();
         if epoch == 4 {
+            assert_eq!(
+                prover.get_commitment().await.unwrap(),
+                prover2.get_commitment().await.unwrap()
+            );
             break;
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
@@ -242,4 +247,8 @@ async fn test_load_persisted_state() {
     spawn(async move { runner.run().await.unwrap() });
     let epoch = prover2.clone().db.get_epoch().unwrap();
     assert_eq!(epoch, 4);
+    assert_eq!(
+        prover.get_commitment().await.unwrap(),
+        prover2.get_commitment().await.unwrap()
+    );
 }

--- a/crates/node_types/prover/src/tests.rs
+++ b/crates/node_types/prover/src/tests.rs
@@ -1,0 +1,193 @@
+use prism_common::tree::Proof;
+use std::{self, sync::Arc};
+
+use crate::{Config, Prover};
+use prism_common::{operation::Operation, test_utils::create_mock_signing_key};
+use prism_da::memory::InMemoryDataAvailabilityLayer;
+use prism_storage::{inmemory::InMemoryDatabase, Database};
+
+// Helper function to create a test prover instance
+async fn create_test_prover() -> Arc<Prover> {
+    let (da_layer, _rx, _brx) = InMemoryDataAvailabilityLayer::new(1);
+    let da_layer = Arc::new(da_layer);
+    let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
+    let cfg = Config::default();
+    Arc::new(Prover::new(db.clone(), da_layer, cfg.clone()).unwrap())
+}
+
+#[tokio::test]
+async fn test_validate_and_queue_update() {
+    let prover = create_test_prover().await;
+
+    let service_key = create_mock_signing_key();
+    let op = Operation::new_register_service("service_id".to_string(), service_key.clone().into());
+
+    prover.clone().validate_and_queue_update(&op).await.unwrap();
+
+    prover.clone().validate_and_queue_update(&op).await.unwrap();
+
+    let pending_ops = prover.pending_operations.read().await;
+    assert_eq!(pending_ops.len(), 2);
+}
+
+#[tokio::test]
+async fn test_process_operation() {
+    let prover = create_test_prover().await;
+
+    let signing_key = create_mock_signing_key();
+    let original_pubkey = signing_key.verifying_key();
+    let service_key = create_mock_signing_key();
+
+    let register_service_op =
+        Operation::new_register_service("service_id".to_string(), service_key.clone().into());
+    let create_account_op = Operation::new_create_account(
+        "test@example.com".to_string(),
+        &signing_key,
+        "service_id".to_string(),
+        &service_key,
+    )
+    .unwrap();
+
+    let proof = prover
+        .process_operation(&register_service_op)
+        .await
+        .unwrap();
+    assert!(matches!(proof, Proof::Insert(_)));
+
+    let proof = prover.process_operation(&create_account_op).await.unwrap();
+    assert!(matches!(proof, Proof::Insert(_)));
+
+    let new_key = create_mock_signing_key();
+    let pubkey = new_key.verifying_key();
+    let add_key_op =
+        Operation::new_add_key("test@example.com".to_string(), pubkey, &signing_key, 0).unwrap();
+
+    let proof = prover.process_operation(&add_key_op).await.unwrap();
+
+    assert!(matches!(proof, Proof::Update(_)));
+
+    // Revoke original key
+    let revoke_op =
+        Operation::new_revoke_key("test@example.com".to_string(), original_pubkey, &new_key, 1)
+            .unwrap();
+    let proof = prover.process_operation(&revoke_op).await.unwrap();
+    assert!(matches!(proof, Proof::Update(_)));
+}
+
+#[tokio::test]
+async fn test_execute_block_with_invalid_tx() {
+    let prover = create_test_prover().await;
+
+    let signing_key_1 = create_mock_signing_key();
+    let signing_key_2 = create_mock_signing_key();
+    let signing_key_3 = create_mock_signing_key();
+    let service_key = create_mock_signing_key();
+
+    let operations = vec![
+        Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
+        Operation::new_create_account(
+            "user1@example.com".to_string(),
+            &signing_key_1,
+            "service_id".to_string(),
+            &service_key,
+        )
+        .unwrap(),
+        // add signing_key_2, so it will be index = 1
+        Operation::new_add_key(
+            "user1@example.com".to_string(),
+            signing_key_2.verifying_key(),
+            &signing_key_1,
+            0,
+        )
+        .unwrap(),
+        // try revoking signing_key_2
+        Operation::new_revoke_key(
+            "user1@example.com".to_string(),
+            signing_key_2.verifying_key(),
+            &signing_key_1,
+            0,
+        )
+        .unwrap(),
+        // and adding in same block.
+        // both of these operations are valid individually, but when processed together it will fail.
+        Operation::new_add_key(
+            "user1@example.com".to_string(),
+            signing_key_3.verifying_key(),
+            &signing_key_2,
+            1,
+        )
+        .unwrap(),
+    ];
+
+    let proofs = prover.execute_block(operations).await.unwrap();
+    assert_eq!(proofs.len(), 4);
+}
+
+#[tokio::test]
+async fn test_execute_block() {
+    let prover = create_test_prover().await;
+
+    let signing_key_1 = create_mock_signing_key();
+    let signing_key_2 = create_mock_signing_key();
+    let new_key = create_mock_signing_key().verifying_key();
+    let service_key = create_mock_signing_key();
+
+    let operations = vec![
+        Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
+        Operation::new_create_account(
+            "user1@example.com".to_string(),
+            &signing_key_1,
+            "service_id".to_string(),
+            &service_key,
+        )
+        .unwrap(),
+        Operation::new_create_account(
+            "user2@example.com".to_string(),
+            &signing_key_2,
+            "service_id".to_string(),
+            &service_key,
+        )
+        .unwrap(),
+        Operation::new_add_key("user1@example.com".to_string(), new_key, &signing_key_1, 0)
+            .unwrap(),
+    ];
+
+    let proofs = prover.execute_block(operations).await.unwrap();
+    assert_eq!(proofs.len(), 4);
+}
+
+#[tokio::test]
+async fn test_finalize_new_epoch() {
+    let prover = create_test_prover().await;
+
+    let signing_key_1 = create_mock_signing_key();
+    let signing_key_2 = create_mock_signing_key();
+    let new_key = create_mock_signing_key().verifying_key();
+    let service_key = create_mock_signing_key();
+
+    let operations = vec![
+        Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
+        Operation::new_create_account(
+            "user1@example.com".to_string(),
+            &signing_key_1,
+            "service_id".to_string(),
+            &service_key,
+        )
+        .unwrap(),
+        Operation::new_create_account(
+            "user2@example.com".to_string(),
+            &signing_key_2,
+            "service_id".to_string(),
+            &service_key,
+        )
+        .unwrap(),
+        Operation::new_add_key("user1@example.com".to_string(), new_key, &signing_key_1, 0)
+            .unwrap(),
+    ];
+
+    let prev_commitment = prover.get_commitment().await.unwrap();
+    prover.finalize_new_epoch(0, operations).await.unwrap();
+
+    let new_commitment = prover.get_commitment().await.unwrap();
+    assert_ne!(prev_commitment, new_commitment);
+}

--- a/crates/node_types/prover/src/tests.rs
+++ b/crates/node_types/prover/src/tests.rs
@@ -1,5 +1,6 @@
 use prism_common::tree::Proof;
-use std::{self, sync::Arc};
+use std::{self, sync::Arc, time::Duration};
+use tokio::spawn;
 
 use crate::{Config, Prover};
 use prism_common::{operation::Operation, test_utils::create_mock_signing_key};
@@ -13,6 +14,32 @@ async fn create_test_prover() -> Arc<Prover> {
     let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let cfg = Config::default();
     Arc::new(Prover::new(db.clone(), da_layer, cfg.clone()).unwrap())
+}
+
+fn create_mock_operations(service_id: String) -> Vec<Operation> {
+    let signing_key_1 = create_mock_signing_key();
+    let signing_key_2 = create_mock_signing_key();
+    let new_key = create_mock_signing_key().verifying_key();
+    let service_key = create_mock_signing_key();
+    vec![
+        Operation::new_register_service(service_id.clone(), service_key.clone().into()),
+        Operation::new_create_account(
+            "user1@example.com".to_string(),
+            &signing_key_1,
+            service_id.clone(),
+            &service_key,
+        )
+        .unwrap(),
+        Operation::new_create_account(
+            "user2@example.com".to_string(),
+            &signing_key_2,
+            service_id.clone(),
+            &service_key,
+        )
+        .unwrap(),
+        Operation::new_add_key("user1@example.com".to_string(), new_key, &signing_key_1, 0)
+            .unwrap(),
+    ]
 }
 
 #[tokio::test]
@@ -127,30 +154,7 @@ async fn test_execute_block_with_invalid_tx() {
 async fn test_execute_block() {
     let prover = create_test_prover().await;
 
-    let signing_key_1 = create_mock_signing_key();
-    let signing_key_2 = create_mock_signing_key();
-    let new_key = create_mock_signing_key().verifying_key();
-    let service_key = create_mock_signing_key();
-
-    let operations = vec![
-        Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
-        Operation::new_create_account(
-            "user1@example.com".to_string(),
-            &signing_key_1,
-            "service_id".to_string(),
-            &service_key,
-        )
-        .unwrap(),
-        Operation::new_create_account(
-            "user2@example.com".to_string(),
-            &signing_key_2,
-            "service_id".to_string(),
-            &service_key,
-        )
-        .unwrap(),
-        Operation::new_add_key("user1@example.com".to_string(), new_key, &signing_key_1, 0)
-            .unwrap(),
-    ];
+    let operations = create_mock_operations("test_service".to_string());
 
     let proofs = prover.execute_block(operations).await.unwrap();
     assert_eq!(proofs.len(), 4);
@@ -159,35 +163,84 @@ async fn test_execute_block() {
 #[tokio::test]
 async fn test_finalize_new_epoch() {
     let prover = create_test_prover().await;
-
-    let signing_key_1 = create_mock_signing_key();
-    let signing_key_2 = create_mock_signing_key();
-    let new_key = create_mock_signing_key().verifying_key();
-    let service_key = create_mock_signing_key();
-
-    let operations = vec![
-        Operation::new_register_service("service_id".to_string(), service_key.clone().into()),
-        Operation::new_create_account(
-            "user1@example.com".to_string(),
-            &signing_key_1,
-            "service_id".to_string(),
-            &service_key,
-        )
-        .unwrap(),
-        Operation::new_create_account(
-            "user2@example.com".to_string(),
-            &signing_key_2,
-            "service_id".to_string(),
-            &service_key,
-        )
-        .unwrap(),
-        Operation::new_add_key("user1@example.com".to_string(), new_key, &signing_key_1, 0)
-            .unwrap(),
-    ];
+    let operations = create_mock_operations("test_service".to_string());
 
     let prev_commitment = prover.get_commitment().await.unwrap();
     prover.finalize_new_epoch(0, operations).await.unwrap();
 
     let new_commitment = prover.get_commitment().await.unwrap();
     assert_ne!(prev_commitment, new_commitment);
+}
+
+#[tokio::test]
+async fn test_restart_sync_from_scratch() {
+    let (da_layer, _rx, mut brx) = InMemoryDataAvailabilityLayer::new(1);
+    let da_layer = Arc::new(da_layer);
+    let db1: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
+    let db2: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
+    let cfg = Config::default();
+    let prover = Arc::new(Prover::new(db1.clone(), da_layer.clone(), cfg.clone()).unwrap());
+
+    let runner = prover.clone();
+    spawn(async move {
+        runner.run().await.unwrap();
+    });
+
+    let operations = create_mock_operations("test_service".to_string());
+
+    for op in operations {
+        prover.clone().validate_and_queue_update(&op).await.unwrap();
+        while let Ok(new_block) = brx.recv().await {
+            if new_block.epoch.is_some() {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(prover.clone().db.get_epoch().unwrap(), 4);
+
+    let prover2 = Arc::new(Prover::new(db2.clone(), da_layer.clone(), cfg.clone()).unwrap());
+    let runner = prover2.clone();
+    spawn(async move { runner.run().await.unwrap() });
+
+    loop {
+        let epoch = prover2.clone().db.get_epoch().unwrap();
+        if epoch == 4 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+#[tokio::test]
+async fn test_load_persisted_state() {
+    let (da_layer, _rx, mut brx) = InMemoryDataAvailabilityLayer::new(1);
+    let da_layer = Arc::new(da_layer);
+    let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
+    let cfg = Config::default();
+    let prover = Arc::new(Prover::new(db.clone(), da_layer.clone(), cfg.clone()).unwrap());
+
+    let runner = prover.clone();
+    spawn(async move {
+        runner.run().await.unwrap();
+    });
+
+    let operations = create_mock_operations("test_service".to_string());
+
+    for op in operations {
+        prover.clone().validate_and_queue_update(&op).await.unwrap();
+        while let Ok(new_block) = brx.recv().await {
+            if new_block.epoch.is_some() {
+                break;
+            }
+        }
+    }
+
+    assert_eq!(prover.clone().db.get_epoch().unwrap(), 4);
+
+    let prover2 = Arc::new(Prover::new(db.clone(), da_layer.clone(), cfg.clone()).unwrap());
+    let runner = prover2.clone();
+    spawn(async move { runner.run().await.unwrap() });
+    let epoch = prover2.clone().db.get_epoch().unwrap();
+    assert_eq!(epoch, 4);
 }

--- a/crates/node_types/prover/src/webserver.rs
+++ b/crates/node_types/prover/src/webserver.rs
@@ -1,5 +1,5 @@
 use crate::Prover;
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use axum::{
     extract::State,
     http::StatusCode,
@@ -25,6 +25,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct WebServerConfig {
+    pub enabled: bool,
     pub host: String,
     pub port: u16,
 }
@@ -32,6 +33,7 @@ pub struct WebServerConfig {
 impl Default for WebServerConfig {
     fn default() -> Self {
         WebServerConfig {
+            enabled: true,
             host: "127.0.0.1".to_string(),
             port: 8089,
         }
@@ -40,6 +42,7 @@ impl Default for WebServerConfig {
 
 pub struct WebServer {
     pub cfg: WebServerConfig,
+    pub session: Arc<Prover>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema)]
@@ -87,11 +90,15 @@ pub struct UserKeyResponse {
 struct ApiDoc;
 
 impl WebServer {
-    pub fn new(cfg: WebServerConfig) -> Self {
-        Self { cfg }
+    pub fn new(cfg: WebServerConfig, session: Arc<Prover>) -> Self {
+        Self { cfg, session }
     }
 
-    pub async fn start(&self, session: Arc<Prover>) -> Result<()> {
+    pub async fn start(&self) -> Result<()> {
+        if !self.cfg.enabled {
+            bail!("Webserver is disabled")
+        }
+
         info!("starting webserver on {}:{}", self.cfg.host, self.cfg.port);
         let app = Router::new()
             .route("/update-entry", post(update_entry))
@@ -99,7 +106,7 @@ impl WebServer {
             .route("/get-current-commitment", get(get_commitment))
             .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
             .layer(CorsLayer::permissive())
-            .with_state(session);
+            .with_state(self.session.clone());
 
         let addr = format!("{}:{}", self.cfg.host, self.cfg.port);
         axum::Server::bind(&addr.parse().unwrap())

--- a/crates/node_types/prover/src/webserver.rs
+++ b/crates/node_types/prover/src/webserver.rs
@@ -35,7 +35,7 @@ impl Default for WebServerConfig {
         WebServerConfig {
             enabled: true,
             host: "127.0.0.1".to_string(),
-            port: 8089,
+            port: 0,
         }
     }
 }

--- a/crates/storage/src/database.rs
+++ b/crates/storage/src/database.rs
@@ -12,6 +12,9 @@ pub trait Database: Send + Sync + TreeReader + TreeWriter {
     fn get_epoch(&self) -> Result<u64>;
     fn set_epoch(&self, epoch: &u64) -> Result<()>;
 
+    fn get_last_synced_height(&self) -> Result<u64>;
+    fn set_last_synced_height(&self, height: &u64) -> Result<()>;
+
     fn flush_database(&self) -> Result<()>;
 }
 

--- a/crates/storage/src/inmemory.rs
+++ b/crates/storage/src/inmemory.rs
@@ -17,6 +17,7 @@ pub struct InMemoryDatabase {
     values: Arc<Mutex<HashMap<(Version, KeyHash), OwnedValue>>>,
     commitments: Arc<Mutex<HashMap<u64, Digest>>>,
     current_epoch: Arc<Mutex<u64>>,
+    sync_height: Arc<Mutex<u64>>,
 }
 
 impl InMemoryDatabase {
@@ -26,6 +27,7 @@ impl InMemoryDatabase {
             values: Arc::new(Mutex::new(HashMap::new())),
             commitments: Arc::new(Mutex::new(HashMap::new())),
             current_epoch: Arc::new(Mutex::new(0)),
+            sync_height: Arc::new(Mutex::new(1)),
         }
     }
 }
@@ -111,6 +113,15 @@ impl Database for InMemoryDatabase {
 
     fn set_epoch(&self, epoch: &u64) -> Result<()> {
         *self.current_epoch.lock().unwrap() = *epoch;
+        Ok(())
+    }
+
+    fn get_last_synced_height(&self) -> Result<u64> {
+        Ok(*self.sync_height.lock().unwrap())
+    }
+
+    fn set_last_synced_height(&self, epoch: &u64) -> Result<()> {
+        *self.sync_height.lock().unwrap() = *epoch;
         Ok(())
     }
 

--- a/crates/storage/src/redis.rs
+++ b/crates/storage/src/redis.rs
@@ -167,6 +167,26 @@ impl Database for RedisConnection {
         Ok(Digest(value.try_into().unwrap()))
     }
 
+    fn get_last_synced_height(&self) -> Result<u64> {
+        let mut con = self.lock_connection()?;
+        con.get("app_state:sync_height").map_err(|_| {
+            anyhow!(DatabaseError::NotFoundError(
+                "current sync height".to_string()
+            ))
+        })
+    }
+
+    fn set_last_synced_height(&self, height: &u64) -> Result<()> {
+        let mut con = self.lock_connection()?;
+        con.set::<&str, &u64, ()>("app_state:sync_height", height)
+            .map_err(|_| {
+                anyhow!(DatabaseError::WriteError(format!(
+                    "sync_height: {}",
+                    height
+                )))
+            })
+    }
+
     fn get_epoch(&self) -> Result<u64> {
         let mut con = self.lock_connection()?;
         con.get("app_state:epoch")

--- a/crates/storage/src/rocksdb.rs
+++ b/crates/storage/src/rocksdb.rs
@@ -47,6 +47,21 @@ impl Database for RocksDBConnection {
         )?)
     }
 
+    fn get_last_synced_height(&self) -> anyhow::Result<u64> {
+        let res = self
+            .connection
+            .get(b"app_state:sync_height")?
+            .ok_or_else(|| DatabaseError::NotFoundError("current sync height".to_string()))?;
+
+        Ok(u64::from_be_bytes(res.try_into().unwrap()))
+    }
+
+    fn set_last_synced_height(&self, height: &u64) -> anyhow::Result<()> {
+        Ok(self
+            .connection
+            .put(b"app_state:sync_height", height.to_be_bytes())?)
+    }
+
     fn get_epoch(&self) -> anyhow::Result<u64> {
         let res = self
             .connection

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -14,7 +14,7 @@ use prism_da::{
     DataAvailabilityLayer,
 };
 use prism_lightclient::LightClient;
-use prism_prover::{webserver::WebServerConfig, Prover};
+use prism_prover::Prover;
 use prism_storage::{inmemory::InMemoryDatabase, Database};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::sync::Arc;
@@ -75,13 +75,15 @@ async fn test_light_client_prover_talking() -> Result<()> {
 
     let mut test_state = TestTreeState::new();
     let _service = test_state.register_service("test_service".to_string());
+    let prover_cfg = prism_prover::Config {
+        key: signing_key,
+        ..prism_prover::Config::default()
+    };
 
     let prover = Arc::new(Prover::new(
         db.clone(),
         bridge_da_layer.clone(),
-        WebServerConfig::default(),
-        0,
-        signing_key.clone(),
+        prover_cfg,
     )?);
 
     let lightclient = Arc::new(LightClient::new(lc_da_layer.clone(), lc_cfg, Some(pubkey)));

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -83,7 +83,7 @@ async fn test_light_client_prover_talking() -> Result<()> {
     let prover = Arc::new(Prover::new(
         db.clone(),
         bridge_da_layer.clone(),
-        prover_cfg,
+        &prover_cfg,
     )?);
 
     let lightclient = Arc::new(LightClient::new(lc_da_layer.clone(), lc_cfg, Some(pubkey)));


### PR DESCRIPTION
This PR introduces full node support via a prover config, and cleans up sync. The next PR will add a fullnode node type to `prism-bin`, and clean up how the application binary config is handled/translated into the prover config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new configuration structure for the Prover, streamlining initialization.
	- Added methods to manage the last synced height in various database implementations (Redis, RocksDB, InMemory).
	- Enhanced WebServer configuration with an enabled flag and dynamic port selection.
	- Added a new Prover struct to manage data availability and processing operations.
	- Expanded public exports to include both Config and Prover from the prover module.
	- Added a new method to the KeyDirectoryTree for loading instances with a specified epoch.

- **Bug Fixes**
	- Improved handling of command line arguments for configuration settings.

- **Documentation**
	- Updated test configurations to reflect changes in the Prover setup.

- **Refactor**
	- Consolidated related parameters into a single configuration structure for better clarity and maintainability.
	- Streamlined the Prover's initialization process by encapsulating parameters into a new configuration structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->