### PR TITLE
ci: nightly toolchain as default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,29 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        run: |
-          rustup toolchain install ${{ matrix.rust.version }} --profile ${{ matrix.rust.profile }}
-          rustup default ${{ matrix.rust.version }}
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
         with:
           version: "23.3"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up cargo cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-${{ hashFiles('**/Cargo.lock') }}
-            cargo-
 
       - name: Run non-integration tests
         run: cargo test --lib --release --features mock_prover -- --skip test_light_client_prover_talking
@@ -61,10 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Rust
-        run: |
-          rustup toolchain install ${{ matrix.rust.version }} --profile ${{ matrix.rust.profile }}
-          rustup default ${{ matrix.rust.version }}
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
@@ -132,21 +113,7 @@ jobs:
           version: "23.3"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
-
-      - name: Set up cargo cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-${{ hashFiles('**/Cargo.lock') }}
-            cargo-
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo-udeps
         uses: taiki-e/cache-cargo-install-action@v1
@@ -168,34 +135,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Rust
-        run: |
-          rustup toolchain install ${{ matrix.rust.version }} --profile ${{ matrix.rust.profile }}
-          rustup default ${{ matrix.rust.version }}
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
         with:
           version: "23.3"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up cargo cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-${{ hashFiles('**/Cargo.lock') }}
-            cargo-
-
-      - name: Add clippy component if not stable
-        if: matrix.rust.version != 'stable'
-        run: rustup component add clippy
 
       - name: Run clippy
         run: cargo clippy --locked --all --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
@@ -32,6 +34,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v2
@@ -100,6 +104,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
 
       - name: Install cargo-udeps
         uses: taiki-e/cache-cargo-install-action@v1
@@ -116,6 +122,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: nightly
           components: clippy
 
       - name: Install Protoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,6 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - version: nightly
-            profile: default
-
     steps:
       - uses: actions/checkout@v4
 
@@ -34,13 +27,6 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - version: nightly
-            profile: minimal
 
     steps:
       - uses: actions/checkout@v4
@@ -125,13 +111,6 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        rust:
-          - version: nightly
-            profile: minimal
 
     steps:
       - uses: actions/checkout@v4

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.79.0"
+channel = "nightly"
 components = ["llvm-tools", "rustc-dev"]


### PR DESCRIPTION
* CI now overrides toolchain channel of rust-toolchain file
* Toolchain set to nightly everywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job to check for unused dependencies in the CI workflow.
	- Enhanced integration testing with new Docker setup steps.

- **Bug Fixes**
	- Streamlined CI process by removing outdated Rust version matrix strategies.

- **Chores**
	- Updated Rust toolchain configuration to use the nightly version for more up-to-date features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->