### PR TITLE
test(prover): Use separate ports when running 2 provers in test

### DIFF
--- a/crates/node_types/prover/src/webserver.rs
+++ b/crates/node_types/prover/src/webserver.rs
@@ -36,7 +36,7 @@ impl Default for WebServerConfig {
         WebServerConfig {
             enabled: true,
             host: "127.0.0.1".to_string(),
-            port: 50524,
+            port: 0,
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The web server now binds to an ephemeral port, allowing for dynamic port assignment at runtime. 

- **Bug Fixes**
	- Adjusted the default port configuration for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->