### PR TITLE
fix: avoid double hashing JMT keys

### DIFF
--- a/crates/common/src/test_utils.rs
+++ b/crates/common/src/test_utils.rs
@@ -60,8 +60,7 @@ impl TestTreeState {
             )
             .unwrap();
 
-        let hashed_id = Digest::hash(&service_id);
-        let key_hash = KeyHash::with::<Hasher>(hashed_id);
+        let key_hash = KeyHash::with::<Hasher>(&service_id);
 
         Service {
             id: service_id.clone(),
@@ -95,8 +94,7 @@ impl TestTreeState {
             )
             .unwrap();
 
-        let hashed_id = Digest::hash(&id);
-        let key_hash = KeyHash::with::<Hasher>(hashed_id);
+        let key_hash = KeyHash::with::<Hasher>(&id);
 
         TestAccount {
             id,
@@ -218,8 +216,7 @@ pub fn create_random_insert(state: &mut TestTreeState, rng: &mut StdRng) -> Inse
         ]);
         let signature = service.sk.sign(&hash.to_bytes());
 
-        let hashed_id = Digest::hash(&random_string);
-        let key_hash = KeyHash::with::<Hasher>(hashed_id);
+        let key_hash = KeyHash::with::<Hasher>(&random_string);
 
         let entry = Hashchain::empty()
             .create_account(
@@ -247,8 +244,7 @@ pub fn create_random_update(state: &mut TestTreeState, rng: &mut StdRng) -> Upda
 
     let key = state.inserted_keys.iter().nth(rng.gen_range(0..state.inserted_keys.len())).unwrap();
 
-    let hashed_id = Digest::hash(key);
-    let key_hash = KeyHash::with::<Hasher>(hashed_id);
+    let key_hash = KeyHash::with::<Hasher>(key);
 
     let Found(mut hc, _) = state.tree.get(key_hash).unwrap() else {
         panic!("No response found for key. Cannot perform update.");

--- a/crates/common/src/transaction_builder.rs
+++ b/crates/common/src/transaction_builder.rs
@@ -190,8 +190,7 @@ impl TransactionBuilder {
         signing_key: &SigningKey,
         key_idx: usize,
     ) -> UncommittedTransaction {
-        let hashed_id = Digest::hash(id);
-        let key_hash = KeyHash::with::<Hasher>(hashed_id);
+        let key_hash = KeyHash::with::<Hasher>(id);
 
         let Ok(Found(hc, _)) = self.tree.get(key_hash) else {
             panic!("No existing hashchain found for {}", id)
@@ -228,8 +227,7 @@ impl TransactionBuilder {
         signing_key: &SigningKey,
         key_idx: usize,
     ) -> UncommittedTransaction {
-        let hashed_id = Digest::hash(id);
-        let key_hash = KeyHash::with::<Hasher>(hashed_id);
+        let key_hash = KeyHash::with::<Hasher>(id);
 
         let Ok(Found(hc, _)) = self.tree.get(key_hash) else {
             panic!("No existing hashchain found for {}", id)
@@ -306,8 +304,7 @@ impl TransactionBuilder {
         signing_key: &SigningKey,
         key_idx: usize,
     ) -> UncommittedTransaction {
-        let hashed_id = Digest::hash(id);
-        let key_hash = KeyHash::with::<Hasher>(hashed_id);
+        let key_hash = KeyHash::with::<Hasher>(id);
 
         let Ok(Found(hc, _)) = self.tree.get(key_hash) else {
             panic!("No existing hashchain found for {}", id)

--- a/crates/common/src/tree/snarkable_tree.rs
+++ b/crates/common/src/tree/snarkable_tree.rs
@@ -33,8 +33,7 @@ where
     fn process_transaction(&mut self, transaction: Transaction) -> Result<Proof> {
         match &transaction.entry.operation {
             Operation::AddKey { .. } | Operation::RevokeKey { .. } | Operation::AddData { .. } => {
-                let hashed_id = Digest::hash(&transaction.id);
-                let key_hash = KeyHash::with::<Hasher>(hashed_id);
+                let key_hash = KeyHash::with::<Hasher>(&transaction.id);
 
                 debug!("updating hashchain for user id {}", transaction.id);
                 let proof = self.update(key_hash, transaction.entry)?;
@@ -52,8 +51,7 @@ where
                     "Id of transaction needs to be equal to operation id"
                 );
 
-                let hashed_id = Digest::hash(id);
-                let account_key_hash = KeyHash::with::<Hasher>(hashed_id);
+                let account_key_hash = KeyHash::with::<Hasher>(id);
 
                 // Verify that the account doesn't already exist
                 if matches!(self.get(account_key_hash)?, Found(_, _)) {
@@ -63,7 +61,7 @@ where
                     )));
                 }
 
-                let service_key_hash = KeyHash::with::<Hasher>(Digest::hash(service_id.as_bytes()));
+                let service_key_hash = KeyHash::with::<Hasher>(service_id);
 
                 let Found(service_hashchain, _) = self.get(service_key_hash)? else {
                     bail!("Failed to get hashchain for service ID {}", service_id);
@@ -100,8 +98,7 @@ where
                     "Id of transaction needs to be equal to operation id"
                 );
 
-                let hashed_id = Digest::hash(id);
-                let key_hash = KeyHash::with::<Hasher>(hashed_id);
+                let key_hash = KeyHash::with::<Hasher>(id);
 
                 debug!("creating new hashchain for service id {}", id);
 

--- a/crates/node_types/prover/src/prover/mod.rs
+++ b/crates/node_types/prover/src/prover/mod.rs
@@ -459,8 +459,7 @@ impl Prover {
 
     pub async fn get_hashchain(&self, id: &String) -> Result<HashchainResponse> {
         let tree = self.tree.read().await;
-        let hashed_id = Digest::hash(id);
-        let key_hash = KeyHash::with::<Hasher>(hashed_id);
+        let key_hash = KeyHash::with::<Hasher>(id);
 
         tree.get(key_hash)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified key hash generation process by using identifiers directly instead of hashed versions across various components.
- **Bug Fixes**
	- Adjusted the `get_hashchain` method to improve how hash chains are retrieved, enhancing its interaction with the underlying data structure.
- **Documentation**
	- Updated method signature for `get_hashchain` in the `Prover` struct to reflect changes in key hash generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->