### PR TITLE
docs(tutorial): link typo

### DIFF
--- a/doc/src/tutorial.md
+++ b/doc/src/tutorial.md
@@ -11,7 +11,7 @@ Prism services are the basis for creating new accounts in the prism protocol.
 To learn more, see [labels](./labels.md).
 
 We will cover:
-1. Starting a [local prism devnet](./architechture.md)
+1. Starting a [local prism devnet](./architecture.md)
 2. Registering a test [service](./labels.md)
 3. Creating [accounts](./datastructures.md) from your service
 4. Adding keys and data to existing accounts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error in the tutorial link, ensuring accurate navigation to the architecture resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->