### PR TITLE
Fix typos in code and documentation

### DIFF
--- a/ci/run-validator.sh
+++ b/ci/run-validator.sh
@@ -94,7 +94,7 @@ provision_light_nodes() {
 
     light_address=$(node_address "$light_name")
 
-    echo "Transfering $BRIDGE_COINS coins to the $light_name"
+    echo "Transferring $BRIDGE_COINS coins to the $light_name"
     echo "y" | celestia-appd tx bank send \
         "$NODE_NAME" \
         "$light_address" \

--- a/crates/node_types/wasm-lightclient/src/worker_communication.rs
+++ b/crates/node_types/wasm-lightclient/src/worker_communication.rs
@@ -56,7 +56,7 @@ impl WorkerClient {
         response_channel
             .recv()
             .await
-            .ok_or_else(|| JsError::new("response channel shoulld  never drop"))?
+            .ok_or_else(|| JsError::new("response channel should never drop"))?
     }
 }
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -17,7 +17,7 @@
 * [Web Proofs](mammothon/reclaim.md)
 
 -----------
-# Prerequites
+# Prerequisite
 
 * [Introduction to Cryptography](./crypto-intro/intro.md)
   * [Symmetric Encryption](./crypto-intro/symmetric.md)


### PR DESCRIPTION


This PR fixes several typos:
- Corrects "Transfering" to "Transferring" in run-validator.sh
- Fixes "shouldd" to "should" in error message in worker_communication.rs
- Changes "Prerequistes" to "Prerequisite" in documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling errors in documentation section headers.

- **Style**
  - Fixed typos in user-facing messages and logs to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->