### PR TITLE
feat: posting gap filler epochs every 300 heights

### DIFF
--- a/crates/cli/src/cfg.rs
+++ b/crates/cli/src/cfg.rs
@@ -5,7 +5,7 @@ use dirs::home_dir;
 use dotenvy::dotenv;
 use prism_errors::{DataAvailabilityError, GeneralError};
 use prism_keys::VerifyingKey;
-use prism_prover::webserver::WebServerConfig;
+use prism_prover::{prover::DEFAULT_MAX_EPOCHLESS_GAP, webserver::WebServerConfig};
 use prism_serde::base64::FromBase64;
 use prism_storage::{
     Database, RedisConnection,
@@ -123,6 +123,8 @@ pub struct Config {
     pub da_layer: DALayerOption,
     pub db: StorageBackend,
     pub telemetry: Option<TelemetryConfig>,
+    /// Maximum number of DA heights the prover will wait before posting a gapfiller proof
+    pub max_epochless_gap: u64,
 }
 
 impl Config {
@@ -135,6 +137,7 @@ impl Config {
             da_layer: DALayerOption::default(),
             db: StorageBackend::RocksDB(RocksDBConfig::new(&format!("{}data", path))),
             telemetry: Some(get_default_telemetry_config()),
+            max_epochless_gap: DEFAULT_MAX_EPOCHLESS_GAP,
         }
     }
 }
@@ -305,6 +308,7 @@ fn apply_command_line_args(config: Config, args: CommandArgs) -> Config {
         keystore_path: args.keystore_path.or(config.keystore_path),
         da_layer: config.da_layer,
         telemetry: config.telemetry,
+        max_epochless_gap: config.max_epochless_gap,
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -117,6 +117,7 @@ async fn main() -> std::io::Result<()> {
                 signing_key,
                 verifying_key,
                 start_height,
+                max_epochless_gap: config.max_epochless_gap,
             };
 
             Arc::new(Prover::new(db, da, &prover_cfg).map_err(|e| {
@@ -151,6 +152,7 @@ async fn main() -> std::io::Result<()> {
                 signing_key,
                 verifying_key,
                 start_height,
+                max_epochless_gap: config.max_epochless_gap,
             };
 
             Arc::new(Prover::new(db, da, &prover_cfg).map_err(|e| {

--- a/crates/node_types/prover/src/prover/mod.rs
+++ b/crates/node_types/prover/src/prover/mod.rs
@@ -38,6 +38,8 @@ use sp1_sdk::{
 };
 use prism_telemetry_registry::metrics_registry::get_metrics;
 
+/// Maximum number of DA heights the prover will wait before posting a gapfiller proof
+pub const DEFAULT_MAX_EPOCHLESS_GAP: u64 = 300;
 pub const BASE_PRISM_ELF: &[u8] =
     include_bytes!("../../../../../elf/base-riscv32im-succinct-zkvm-elf");
 pub const RECURSIVE_PRISM_ELF: &[u8] =
@@ -66,6 +68,10 @@ pub struct Config {
 
     /// DA layer height the prover should start syncing transactions from.
     pub start_height: u64,
+    ///
+    /// Maximum DA height gap between two epochs; If exceeded, the prover will
+    /// repost the last epoch to aid LN syncing.
+    pub max_epochless_gap: u64,
 }
 
 impl Default for Config {
@@ -79,6 +85,7 @@ impl Default for Config {
             signing_key: signing_key.clone(),
             verifying_key: signing_key.verifying_key(),
             start_height: 1,
+            max_epochless_gap: DEFAULT_MAX_EPOCHLESS_GAP,
         }
     }
 }
@@ -97,12 +104,9 @@ impl Config {
             SigningKey::new_with_algorithm(algorithm).context("Failed to create signing key")?;
 
         Ok(Config {
-            prover: true,
-            batcher: true,
-            webserver: WebServerConfig::default(),
             signing_key: signing_key.clone(),
             verifying_key: signing_key.verifying_key(),
-            start_height: 1,
+            ..Config::default()
         })
     }
 }
@@ -128,6 +132,9 @@ pub struct Prover {
     recursive_prover_client: Arc<RwLock<CpuProver>>,
     recursive_proving_key: SP1ProvingKey,
     recursive_verifying_key: SP1VerifyingKey,
+
+    /// The DA height of the latest epoch.
+    latest_epoch_da_height: Arc<RwLock<u64>>,
 }
 
 #[allow(dead_code)]
@@ -175,6 +182,7 @@ impl Prover {
             recursive_prover_client: Arc::new(RwLock::new(recursive_prover_client)),
             tree,
             pending_transactions: Arc::new(RwLock::new(Vec::new())),
+            latest_epoch_da_height: Arc::new(RwLock::new(0)),
         })
     }
 
@@ -303,6 +311,15 @@ impl Prover {
         // be included in the next finalized epoch.
         if !transactions.is_empty() {
             buffered_transactions.extend(transactions);
+            return Ok(());
+        }
+
+        // post gap filler proof if max gap has been reached
+        let latest_epoch_height = *self.latest_epoch_da_height.read().await;
+        if latest_epoch_height != 0
+            && height.saturating_sub(latest_epoch_height) >= self.cfg.max_epochless_gap
+        {
+            self.finalize_new_epoch(current_epoch, Vec::new()).await?;
         }
 
         if let Some(metrics) = get_metrics() {
@@ -423,18 +440,23 @@ impl Prover {
         Ok(proofs)
     }
 
+    /// Finalizes a new epoch by processing the given transactions, proving the epoch,
+    /// and submitting it to the data availability layer.
+    /// Returns the height on the DA layer where the epoch was submitted.
     async fn finalize_new_epoch(
         &self,
         epoch_height: u64,
         transactions: Vec<Transaction>,
-    ) -> Result<()> {
+    ) -> Result<u64> {
         let mut tree = self.tree.write().await;
         let batch = tree.process_batch(transactions)?;
         batch.verify()?;
 
         let finalized_epoch = self.prove_epoch(epoch_height, &batch).await?;
 
-        self.da.submit_finalized_epoch(finalized_epoch).await?;
+        let da_height = self.da.submit_finalized_epoch(finalized_epoch).await?;
+        let mut latest_da_height = self.latest_epoch_da_height.write().await;
+        *latest_da_height = da_height;
 
         let new_epoch_height = epoch_height + 1;
         self.db.set_commitment(&new_epoch_height, &batch.new_root)?;
@@ -442,7 +464,7 @@ impl Prover {
 
         info!("finalized new epoch at height {}", epoch_height);
 
-        Ok(())
+        Ok(da_height)
     }
 
     async fn prove_with_base_prover(

--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -155,14 +155,14 @@ async fn test_restart_sync_from_scratch(algorithm: CryptoAlgorithm) {
         }
     }
 
-    assert_eq!(prover.clone().db.get_epoch().unwrap(), 4);
+    assert_eq!(prover.clone().db.get_epoch_height().unwrap(), 4);
 
     let prover2 = Arc::new(Prover::new(db2.clone(), da_layer.clone(), &cfg).unwrap());
     let runner = prover2.clone();
     spawn(async move { runner.run().await.unwrap() });
 
     loop {
-        let epoch = prover2.clone().db.get_epoch().unwrap();
+        let epoch = prover2.clone().db.get_epoch_height().unwrap();
         if epoch == 4 {
             assert_eq!(
                 prover.get_commitment().await.unwrap(),
@@ -197,12 +197,12 @@ async fn test_load_persisted_state(algorithm: CryptoAlgorithm) {
         }
     }
 
-    assert_eq!(prover.clone().db.get_epoch().unwrap(), 4);
+    assert_eq!(prover.clone().db.get_epoch_height().unwrap(), 4);
 
     let prover2 = Arc::new(Prover::new(db.clone(), da_layer.clone(), &cfg).unwrap());
     let runner = prover2.clone();
     spawn(async move { runner.run().await.unwrap() });
-    let epoch = prover2.clone().db.get_epoch().unwrap();
+    let epoch = prover2.clone().db.get_epoch_height().unwrap();
     assert_eq!(epoch, 4);
     assert_eq!(
         prover.get_commitment().await.unwrap(),

--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -38,14 +38,6 @@ fn create_mock_transactions(algorithm: CryptoAlgorithm, service_id: String) -> V
 
 async fn test_posts_epoch_after_max_gap(algorithm: CryptoAlgorithm) {
     let prover = create_test_prover(algorithm).await;
-    let (da_layer, _rx, _brx) = InMemoryDataAvailabilityLayer::new(1);
-    let da_layer = Arc::new(da_layer);
-    let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
-    let cfg = Config {
-        max_epochless_gap: 5,
-        ..Config::default_with_key_algorithm(algorithm).unwrap()
-    };
-    Arc::new(Prover::new(db.clone(), da_layer, &cfg).unwrap());
 
     let prover_handle = prover.clone();
     spawn(async move {

--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -12,7 +12,10 @@ async fn create_test_prover(algorithm: CryptoAlgorithm) -> Arc<Prover> {
     let (da_layer, _rx, _brx) = InMemoryDataAvailabilityLayer::new(1);
     let da_layer = Arc::new(da_layer);
     let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
-    let cfg = Config::default_with_key_algorithm(algorithm).unwrap();
+    let cfg = Config {
+        max_epochless_gap: 5,
+        ..Config::default_with_key_algorithm(algorithm).unwrap()
+    };
     Arc::new(Prover::new(db.clone(), da_layer, &cfg).unwrap())
 }
 
@@ -31,6 +34,86 @@ fn create_mock_transactions(algorithm: CryptoAlgorithm, service_id: String) -> V
             .add_random_key_verified_with_root(algorithm, "user1@example.com")
             .commit(),
     ]
+}
+
+async fn test_posts_epoch_after_max_gap(algorithm: CryptoAlgorithm) {
+    let prover = create_test_prover(algorithm).await;
+    let (da_layer, _rx, _brx) = InMemoryDataAvailabilityLayer::new(1);
+    let da_layer = Arc::new(da_layer);
+    let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
+    let cfg = Config {
+        max_epochless_gap: 5,
+        ..Config::default_with_key_algorithm(algorithm).unwrap()
+    };
+    Arc::new(Prover::new(db.clone(), da_layer, &cfg).unwrap());
+
+    let prover_handle = prover.clone();
+    spawn(async move {
+        prover_handle.run().await.unwrap();
+    });
+
+    let mut rx = prover.da.subscribe_to_heights();
+
+    // Wait for initial blocks to be produced
+    loop {
+        let height = rx.recv().await.unwrap();
+        if height >= 10 {
+            break;
+        }
+    }
+
+    // Ensure no gap proof has been created
+    assert!(prover.da.get_finalized_epoch(0).await.unwrap().is_none());
+
+    // Create and submit transactions
+    let test_transactions = create_mock_transactions(algorithm, "test_service".to_string());
+
+    // Verify commitment changes after epoch finalization
+    let commitment_before_epoch = prover.get_commitment().await.unwrap();
+    let initial_epoch_height = prover.finalize_new_epoch(0, test_transactions).await.unwrap();
+    let commitment_after_epoch = prover.get_commitment().await.unwrap();
+    assert_ne!(
+        commitment_before_epoch, commitment_after_epoch,
+        "Commitment should change after epoch finalization"
+    );
+
+    // Give some time for the initial epoch proof to be posted
+    loop {
+        let height = rx.recv().await.unwrap();
+        if height >= initial_epoch_height {
+            break;
+        }
+    }
+    let initial_epoch = prover.da.get_finalized_epoch(initial_epoch_height).await.unwrap().unwrap();
+
+    // Wait for gap length
+    loop {
+        let height = rx.recv().await.unwrap();
+        if height >= initial_epoch_height + 6 {
+            break;
+        }
+    }
+
+    let current_epoch_height = *prover.latest_epoch_da_height.read().await;
+
+    // Give some time for the gap proof to be posted
+    loop {
+        let height = rx.recv().await.unwrap();
+        if height >= current_epoch_height {
+            break;
+        }
+    }
+    // Verify gap proof contents
+    let gap_proof = prover.da.get_finalized_epoch(current_epoch_height).await.unwrap().unwrap();
+    assert_eq!(
+        gap_proof.height,
+        initial_epoch.height + 1,
+        "Gap proof should be at expected height"
+    );
+    assert_eq!(
+        gap_proof.current_commitment, commitment_after_epoch.commitment,
+        "Gap proof should contain the correct commitment"
+    );
 }
 
 async fn test_validate_and_queue_update(algorithm: CryptoAlgorithm) {
@@ -238,3 +321,4 @@ generate_algorithm_tests!(test_execute_block);
 generate_algorithm_tests!(test_finalize_new_epoch);
 generate_algorithm_tests!(test_restart_sync_from_scratch);
 generate_algorithm_tests!(test_load_persisted_state);
+generate_algorithm_tests!(test_posts_epoch_after_max_gap);

--- a/crates/storage/src/database.rs
+++ b/crates/storage/src/database.rs
@@ -17,8 +17,8 @@ pub trait Database: Send + Sync + TreeReader + TreeWriter {
     fn get_commitment(&self, epoch: &u64) -> Result<Digest>;
     fn set_commitment(&self, epoch: &u64, commitment: &Digest) -> Result<()>;
 
-    fn get_epoch(&self) -> Result<u64>;
-    fn set_epoch(&self, epoch: &u64) -> Result<()>;
+    fn get_epoch_height(&self) -> Result<u64>;
+    fn set_epoch_height(&self, epoch: &u64) -> Result<()>;
 
     fn get_last_synced_height(&self) -> Result<u64>;
     fn set_last_synced_height(&self, height: &u64) -> Result<()>;

--- a/crates/storage/src/inmemory.rs
+++ b/crates/storage/src/inmemory.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use jmt::{
-    storage::{LeafNode, Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
     KeyHash, OwnedValue, Version,
+    storage::{LeafNode, Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
 };
 use prism_common::digest::Digest;
 use prism_errors::DatabaseError;
@@ -102,11 +102,11 @@ impl Database for InMemoryDatabase {
         Ok(())
     }
 
-    fn get_epoch(&self) -> Result<u64> {
+    fn get_epoch_height(&self) -> Result<u64> {
         Ok(*self.current_epoch.lock().unwrap())
     }
 
-    fn set_epoch(&self, epoch: &u64) -> Result<()> {
+    fn set_epoch_height(&self, epoch: &u64) -> Result<()> {
         *self.current_epoch.lock().unwrap() = *epoch;
         Ok(())
     }

--- a/crates/storage/src/redis.rs
+++ b/crates/storage/src/redis.rs
@@ -1,7 +1,7 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use jmt::{
-    storage::{LeafNode, Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
     KeyHash, OwnedValue, Version,
+    storage::{LeafNode, Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
 };
 use prism_common::digest::Digest;
 use prism_serde::{
@@ -20,7 +20,7 @@ use std::{
 
 use prism_errors::DatabaseError;
 
-use crate::database::{convert_to_connection_error, Database};
+use crate::database::{Database, convert_to_connection_error};
 use tracing::debug;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -184,13 +184,13 @@ impl Database for RedisConnection {
         })
     }
 
-    fn get_epoch(&self) -> Result<u64> {
+    fn get_epoch_height(&self) -> Result<u64> {
         let mut con = self.lock_connection()?;
         con.get("app_state:epoch")
             .map_err(|_| anyhow!(DatabaseError::NotFoundError("current epoch".to_string())))
     }
 
-    fn set_epoch(&self, epoch: &u64) -> Result<()> {
+    fn set_epoch_height(&self, epoch: &u64) -> Result<()> {
         let mut con = self.lock_connection()?;
         con.set::<&str, &u64, ()>("app_state:epoch", epoch)
             .map_err(|_| anyhow!(DatabaseError::WriteError(format!("epoch: {}", epoch))))

--- a/crates/storage/src/rocksdb.rs
+++ b/crates/storage/src/rocksdb.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use crate::Database;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use jmt::{
-    storage::{LeafNode, Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
     KeyHash, OwnedValue, Version,
+    storage::{LeafNode, Node, NodeBatch, NodeKey, TreeReader, TreeWriter},
 };
 use prism_common::digest::Digest;
 use prism_errors::DatabaseError;
@@ -12,7 +12,7 @@ use prism_serde::{
     binary::{FromBinary, ToBinary},
     hex::{FromHex, ToHex},
 };
-use rocksdb::{DBWithThreadMode, MultiThreaded, Options, DB};
+use rocksdb::{DB, DBWithThreadMode, MultiThreaded, Options};
 use serde::{Deserialize, Serialize};
 
 const KEY_PREFIX_COMMITMENTS: &str = "commitments:epoch_";
@@ -87,7 +87,7 @@ impl Database for RocksDBConnection {
         Ok(self.connection.put(b"app_state:sync_height", height.to_be_bytes())?)
     }
 
-    fn get_epoch(&self) -> anyhow::Result<u64> {
+    fn get_epoch_height(&self) -> anyhow::Result<u64> {
         let res = self
             .connection
             .get(b"app_state:epoch")?
@@ -98,7 +98,7 @@ impl Database for RocksDBConnection {
         })?))
     }
 
-    fn set_epoch(&self, epoch: &u64) -> anyhow::Result<()> {
+    fn set_epoch_height(&self, epoch: &u64) -> anyhow::Result<()> {
         Ok(self.connection.put(b"app_state:epoch", epoch.to_be_bytes())?)
     }
 
@@ -219,8 +219,8 @@ mod tests {
 
         let epoch = 1;
 
-        db.set_epoch(&epoch).unwrap();
-        let read_epoch = db.get_epoch().unwrap();
+        db.set_epoch_height(&epoch).unwrap();
+        let read_epoch = db.get_epoch_height().unwrap();
 
         assert_eq!(read_epoch, epoch);
     }


### PR DESCRIPTION
This will significantly speed up light node sync when the network is not very active

Closes #93 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable setting to control the maximum gap between finalized epochs before a gapfiller proof is posted.
  - The system now automatically posts a gapfiller proof if the gap exceeds the configured threshold.

- **Bug Fixes**
  - Improved detection and handling of gaps in finalized epochs to ensure data availability and consistency.

- **Tests**
  - Added a new test to verify that gapfiller proofs are posted when the maximum allowed gap is exceeded.

- **Refactor**
  - Renamed methods related to epoch height in database interfaces for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->