### PR TITLE
fixed dead link Dockerfile.validator

### DIFF
--- a/ci/Dockerfile.validator
+++ b/ci/Dockerfile.validator
@@ -2,7 +2,7 @@
 
 # A dockerfile for the celestia validator in consensus layer
 # Based on:
-# https://github.com/celestiaorg/celestia-app/blob/main/Dockerfile
+# https://github.com/celestiaorg/celestia-app/blob/main/docker/txsim/Dockerfile
 FROM docker.io/alpine:3.21.0
 
 ENV CELESTIA_HOME=/root


### PR DESCRIPTION
Hi, I fixed dead link in the documentation and replaced with working ones.

https://github.com/celestiaorg/celestia-app/blob/main/Dockerfile - dead link
https://github.com/celestiaorg/celestia-app/blob/main/docker/txsim/Dockerfile - new link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the reference link in the Dockerfile comment to point to a more specific source Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->