### PR TITLE
fix: Changed default port to 41997 except for tests

### DIFF
--- a/crates/node_types/prover/src/prover/tests.rs
+++ b/crates/node_types/prover/src/prover/tests.rs
@@ -16,6 +16,7 @@ async fn create_test_prover(algorithm: CryptoAlgorithm) -> Arc<Prover> {
     let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let mut cfg = Config::default_with_key_algorithm(algorithm).unwrap();
     cfg.syncer.max_epochless_gap = 5;
+    cfg.webserver.port = 0;
     Arc::new(Prover::new(db.clone(), da_layer, &cfg, CancellationToken::new()).unwrap())
 }
 
@@ -243,7 +244,8 @@ async fn test_restart_sync_from_scratch() {
     let da_layer = Arc::new(da_layer);
     let db1: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let db2: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
-    let cfg = Config::default_with_key_algorithm(CryptoAlgorithm::Ed25519).unwrap();
+    let mut cfg = Config::default_with_key_algorithm(CryptoAlgorithm::Ed25519).unwrap();
+    cfg.webserver.port = 0;
     let prover = Arc::new(
         Prover::new(
             db1.clone(),
@@ -310,6 +312,7 @@ async fn test_prover_fullnode_commitment_sync_with_racing_transactions() {
     let prover_db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
     let mut prover_cfg = Config::default_with_key_algorithm(CryptoAlgorithm::Ed25519).unwrap();
     prover_cfg.syncer.prover_enabled = true;
+    prover_cfg.webserver.port = 0;
     let prover = Arc::new(
         Prover::new(
             prover_db.clone(),
@@ -325,6 +328,7 @@ async fn test_prover_fullnode_commitment_sync_with_racing_transactions() {
     let mut fullnode_cfg = Config::default_with_key_algorithm(CryptoAlgorithm::Ed25519).unwrap();
     fullnode_cfg.syncer.prover_enabled = false;
     fullnode_cfg.syncer.verifying_key = prover_cfg.syncer.verifying_key.clone();
+    fullnode_cfg.webserver.port = 0;
     let fullnode = Arc::new(
         Prover::new(
             fullnode_db.clone(),
@@ -432,7 +436,8 @@ async fn test_load_persisted_state() {
     let (da_layer, _rx, mut brx) = InMemoryDataAvailabilityLayer::new(Duration::from_millis(500));
     let da_layer = Arc::new(da_layer);
     let db: Arc<Box<dyn Database>> = Arc::new(Box::new(InMemoryDatabase::new()));
-    let cfg = Config::default_with_key_algorithm(CryptoAlgorithm::Ed25519).unwrap();
+    let mut cfg = Config::default_with_key_algorithm(CryptoAlgorithm::Ed25519).unwrap();
+    cfg.webserver.port = 0;
     let prover = Arc::new(
         Prover::new(db.clone(), da_layer.clone(), &cfg, CancellationToken::new()).unwrap(),
     );

--- a/crates/node_types/prover/src/webserver.rs
+++ b/crates/node_types/prover/src/webserver.rs
@@ -32,7 +32,7 @@ impl Default for WebServerConfig {
         WebServerConfig {
             enabled: true,
             host: "127.0.0.1".to_string(),
-            port: 0,
+            port: 41997,
         }
     }
 }


### PR DESCRIPTION
Closes #214 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test reliability by updating test configurations to use a non-conflicting web server port.
- **Chores**
  - Changed the default web server port to 41997 for new instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->