### PR TITLE
refactor(da): `FinalizedEpoch`s are now returned as `Vec`s not `Option`s

### DIFF
--- a/crates/da/src/celestia/light_client.rs
+++ b/crates/da/src/celestia/light_client.rs
@@ -189,9 +189,6 @@ impl LightDataAvailabilityLayer for LightClientConnection {
 
         match node.request_all_blobs(&header, self.snark_namespace, None).await {
             Ok(blobs) => {
-                if blobs.is_empty() {
-                    return Ok(vec![]);
-                }
                 let epochs: Vec<FinalizedEpoch> = blobs
                     .into_iter()
                     .filter_map(|blob| match FinalizedEpoch::try_from(&blob) {

--- a/crates/da/src/celestia/light_client.rs
+++ b/crates/da/src/celestia/light_client.rs
@@ -205,13 +205,6 @@ impl LightDataAvailabilityLayer for LightClientConnection {
                         }
                     })
                     .collect();
-                // let blob = blobs.into_iter().next().unwrap();
-                // let epoch = FinalizedEpoch::try_from(&blob).map_err(|_| {
-                //     anyhow!(GeneralError::ParsingError(format!(
-                //         "marshalling blob from height {} to epoch json: {:?}",
-                //         height, &blob
-                //     )))
-                // })?;
                 Ok(epochs)
             }
             Err(e) => Err(anyhow!(DataAvailabilityError::DataRetrievalError(

--- a/crates/da/src/celestia/light_client.rs
+++ b/crates/da/src/celestia/light_client.rs
@@ -10,10 +10,10 @@ use lumina_node::{
     events::EventSubscriber,
     store::{EitherStore, InMemoryStore, StoreError},
 };
-use prism_errors::{DataAvailabilityError, GeneralError};
+use prism_errors::DataAvailabilityError;
 use std::{self, sync::Arc};
 use tokio::sync::{Mutex, RwLock};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 #[cfg(target_arch = "wasm32")]
 use {
@@ -169,7 +169,7 @@ impl LightDataAvailabilityLayer for LightClientConnection {
         Some(self.event_subscriber.clone())
     }
 
-    async fn get_finalized_epoch(&self, height: u64) -> Result<Option<FinalizedEpoch>> {
+    async fn get_finalized_epoch(&self, height: u64) -> Result<Vec<FinalizedEpoch>> {
         trace!(
             "searching for epoch on da layer at height {} under namespace",
             height
@@ -190,16 +190,29 @@ impl LightDataAvailabilityLayer for LightClientConnection {
         match node.request_all_blobs(&header, self.snark_namespace, None).await {
             Ok(blobs) => {
                 if blobs.is_empty() {
-                    return Ok(None);
+                    return Ok(vec![]);
                 }
-                let blob = blobs.into_iter().next().unwrap();
-                let epoch = FinalizedEpoch::try_from(&blob).map_err(|_| {
-                    anyhow!(GeneralError::ParsingError(format!(
-                        "marshalling blob from height {} to epoch json: {:?}",
-                        height, &blob
-                    )))
-                })?;
-                Ok(Some(epoch))
+                let epochs: Vec<FinalizedEpoch> = blobs
+                    .into_iter()
+                    .filter_map(|blob| match FinalizedEpoch::try_from(&blob) {
+                        Ok(epoch) => Some(epoch),
+                        Err(_) => {
+                            warn!(
+                                "marshalling blob from height {} to epoch json: {:?}",
+                                height, &blob
+                            );
+                            None
+                        }
+                    })
+                    .collect();
+                // let blob = blobs.into_iter().next().unwrap();
+                // let epoch = FinalizedEpoch::try_from(&blob).map_err(|_| {
+                //     anyhow!(GeneralError::ParsingError(format!(
+                //         "marshalling blob from height {} to epoch json: {:?}",
+                //         height, &blob
+                //     )))
+                // })?;
+                Ok(epochs)
             }
             Err(e) => Err(anyhow!(DataAvailabilityError::DataRetrievalError(
                 height,

--- a/crates/da/src/lib.rs
+++ b/crates/da/src/lib.rs
@@ -116,7 +116,7 @@ impl TryFrom<&Blob> for FinalizedEpoch {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 pub trait LightDataAvailabilityLayer {
-    async fn get_finalized_epoch(&self, height: u64) -> Result<Option<FinalizedEpoch>>;
+    async fn get_finalized_epoch(&self, height: u64) -> Result<Vec<FinalizedEpoch>>;
 
     // starts the event subscriber, optional because inmemory and rpc based fullnode still need the start function
     fn event_subscriber(&self) -> Option<Arc<Mutex<EventSubscriber>>>;

--- a/crates/node_types/prover/src/syncer.rs
+++ b/crates/node_types/prover/src/syncer.rs
@@ -148,7 +148,7 @@ impl Syncer {
             "DA query at height {}: {} transactions, epoch present: {}",
             height,
             transactions.len(),
-            epoch_result.is_some()
+            !epoch_result.is_empty()
         );
 
         debug!(
@@ -158,12 +158,14 @@ impl Syncer {
             next_epoch_height
         );
 
-        if let Some(epoch) = epoch_result {
-            debug!(
-                "Found finalized epoch {} at height {}",
-                epoch.height, height
-            );
-            self.process_epoch(epoch).await?;
+        if !epoch_result.is_empty() {
+            for epoch in epoch_result {
+                debug!(
+                    "Found finalized epoch {} at height {}",
+                    epoch.height, height
+                );
+                self.process_epoch(epoch).await?;
+            }
         } else {
             debug!("No epoch found at height {}", height);
         }


### PR DESCRIPTION
closes #144 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced support for handling and processing multiple finalized epochs at a given height across data availability and light client components.

- **Bug Fixes**
  - Improved robustness in epoch retrieval and processing, ensuring all valid epochs are collected and handled, even when multiple are present.

- **Tests**
  - Updated test logic to accommodate multiple epochs per block, improving test coverage for the new multi-epoch handling.

- **Refactor**
  - Streamlined internal structures and methods to work with collections of epochs instead of single optional epochs, supporting more flexible data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->