### PR TITLE
docs: fix broken link

### DIFF
--- a/doc/book/tutorial.html
+++ b/doc/book/tutorial.html
@@ -186,7 +186,7 @@
 To learn more, see <a href="./labels.html">labels</a>.</p>
 <p>We will cover:</p>
 <ol>
-<li>Starting a <a href="./architechture.html">local prism devnet</a></li>
+<li>Starting a <a href="./architecture.html">local prism devnet</a></li>
 <li>Registering a test <a href="./labels.html">service</a></li>
 <li>Creating <a href="./datastructures.html">accounts</a> from your service</li>
 <li>Adding keys and data to existing accounts</li>


### PR DESCRIPTION
Fix broken link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a typo in a hyperlink within the tutorial, ensuring it now points to the correct page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->