### PR TITLE
chore: fix some typos in comment

### DIFF
--- a/crates/keys/src/errors.rs
+++ b/crates/keys/src/errors.rs
@@ -52,7 +52,7 @@ pub enum ParseError {
     #[error("Invalid key bytes for algorithm: {0}")]
     InvalidKeyBytes(String),
 
-    #[error("A parsing error occured: {0}")]
+    #[error("A parsing error occurred: {0}")]
     GeneralError(String),
 }
 
@@ -73,6 +73,6 @@ pub enum VerificationError {
     #[error("{0} vk {1} DER format is not implemented")]
     NotImplementedError(String, String),
 
-    #[error("A verification error occured: {0}")]
+    #[error("A verification error occurred: {0}")]
     GeneralError(String),
 }

--- a/crates/node_types/wasm-lightclient/src/tests/mod.rs
+++ b/crates/node_types/wasm-lightclient/src/tests/mod.rs
@@ -208,7 +208,7 @@ mod tests {
 
         // Ready and height update to 100 should be received, is also be used here as test for
         // backwards sync, recursive verification etc., maybe we could write some extra tests if we
-        // should seperate these cases.
+        // should separate these cases.
         assert!(events.len() > 0);
         assert!(events.iter().any(|e| e == "Updated DA height to 100"));
         assert!(events.iter().any(|e| e == "Starting backwards sync at height 100"));


### PR DESCRIPTION
fix some typos in comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in error messages to display "occurred" instead of "occured".

* **Documentation**
  * Fixed a typo in a test comment, updating "seperate" to "separate".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->