### PR TITLE
Fix broken link to Prism Account Sources in reclaim.html

### DIFF
--- a/doc/book/mammothon/reclaim.html
+++ b/doc/book/mammothon/reclaim.html
@@ -193,7 +193,7 @@
 <h2 id="resources"><a class="header" href="#resources">Resources</a></h2>
 <ul>
 <li><a href="https://www.reclaimprotocol.org">Reclaim Protocol</a></li>
-<li><a href="./labels.html">Prism Account Sources</a></li>
+<li><a href="../labels.html">Prism Account Sources</a></li>
 </ul>
 
                     </main>


### PR DESCRIPTION
Updated the link to "Prism Account Sources" in doc/book/mammothon/reclaim.html to point to the correct location (../labels.html). This resolves a broken link issue where the previous path (./labels.html) could not be found, ensuring users can now access the intended resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Prism Account Sources" link in the Resources section to point to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->