### PR TITLE
feat(prover): implemented display for digest and succinct proof

### DIFF
--- a/crates/common/src/digest.rs
+++ b/crates/common/src/digest.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -11,7 +11,7 @@ use prism_serde::{
 use sha2::{Digest as _, Sha256};
 use utoipa::ToSchema;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Copy, ToSchema)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Copy, ToSchema)]
 #[schema(
     value_type = String,
     format = "hex",
@@ -92,6 +92,12 @@ impl FromBase64 for Digest {
 }
 
 impl Display for Digest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
+}
+
+impl Debug for Digest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.to_hex())
     }

--- a/crates/da/src/lib.rs
+++ b/crates/da/src/lib.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    fmt::{Debug, Display},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use celestia_types::Blob;
@@ -43,6 +46,17 @@ pub struct SuccinctProof {
     /// Can be used by `sp1_verifier::groth16::Groth16Verifier::verify` as the
     /// `public_values` field.
     pub public_values: Vec<u8>,
+}
+
+impl Display for SuccinctProof {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "(proof: {}, public_values: {})",
+            self.proof_bytes.to_hex(),
+            self.public_values.to_hex()
+        )
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
I implemented display for digest and succinct proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved formatting for displaying SuccinctProof details in a readable string format.

* **Refactor**
  * Updated how Digest details are formatted for debugging, ensuring a consistent and clear hexadecimal representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->