### PR TITLE
feat(keys): added coverage for FinalizedEpoch::verify_signature map_errs

### DIFF
--- a/crates/keys/src/tests/mod.rs
+++ b/crates/keys/src/tests/mod.rs
@@ -350,4 +350,29 @@ mod key_tests {
         let result = VerifyingKey::try_from(encoded);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_verifying_key_with_invalid_bytes() {
+        let invalid_bytes = [0u8; 1];
+
+        let result =
+            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Ed25519, &invalid_bytes);
+        assert!(result.is_err());
+
+        let result =
+            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Secp256k1, &invalid_bytes);
+        assert!(result.is_err());
+
+        let result =
+            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Secp256r1, &invalid_bytes);
+        assert!(result.is_err());
+
+        let result =
+            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Eip191, &invalid_bytes);
+        assert!(result.is_err());
+
+        let result =
+            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::CosmosAdr36, &invalid_bytes);
+        assert!(result.is_err());
+    }
 }

--- a/crates/keys/src/tests/mod.rs
+++ b/crates/keys/src/tests/mod.rs
@@ -355,24 +355,17 @@ mod key_tests {
     fn test_verifying_key_with_invalid_bytes() {
         let invalid_bytes = [0u8; 1];
 
-        let result =
-            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Ed25519, &invalid_bytes);
-        assert!(result.is_err());
+        let algorithms = [
+            CryptoAlgorithm::Ed25519,
+            CryptoAlgorithm::Secp256k1,
+            CryptoAlgorithm::Secp256r1,
+            CryptoAlgorithm::Eip191,
+            CryptoAlgorithm::CosmosAdr36,
+        ];
 
-        let result =
-            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Secp256k1, &invalid_bytes);
-        assert!(result.is_err());
-
-        let result =
-            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Secp256r1, &invalid_bytes);
-        assert!(result.is_err());
-
-        let result =
-            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::Eip191, &invalid_bytes);
-        assert!(result.is_err());
-
-        let result =
-            VerifyingKey::from_algorithm_and_bytes(CryptoAlgorithm::CosmosAdr36, &invalid_bytes);
-        assert!(result.is_err());
+        for algorithm in algorithms {
+            let result = VerifyingKey::from_algorithm_and_bytes(algorithm, &invalid_bytes);
+            assert!(result.is_err());
+        }
     }
 }


### PR DESCRIPTION
Added a test that gives each algorithm invalid bytes so that each map_err gets activated.