### PR TITLE
fix: correct path to labels.md in reclaim.md

### DIFF
--- a/doc/src/mammothon/reclaim.md
+++ b/doc/src/mammothon/reclaim.md
@@ -15,4 +15,4 @@ The project has these rough requirements:
 
 ## Resources
 - [Reclaim Protocol](https://www.reclaimprotocol.org)
-- [Prism Account Sources](./labels.md)
+- [Prism Account Sources](../labels.md)


### PR DESCRIPTION
Fix broken link in doc/src/mammothon/reclaim.md by changing
./labels.md to ../labels.md since labels.md is located in the
parent directory doc/src/ rather than in the mammothon subdirectory.

