### PR TITLE
Fix broken link to labels.html in print.html documentation

### DIFF
--- a/doc/book/print.html
+++ b/doc/book/print.html
@@ -906,7 +906,7 @@ This document intends to only be a rough outline of the architecture and flow of
 <h2 id="resources-1"><a class="header" href="#resources-1">Resources</a></h2>
 <ul>
 <li><a href="https://www.reclaimprotocol.org">Reclaim Protocol</a></li>
-<li><a href="mammothon/./labels.html">Prism Account Sources</a></li>
+<li><a href="labels.html">Prism Account Sources</a></li>
 </ul>
 <div style="break-before: page; page-break-before: always;"></div><link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css">
 <h1 id="introduction-to-cryptography"><a class="header" href="#introduction-to-cryptography">Introduction to Cryptography</a></h1>


### PR DESCRIPTION
Fix broken link to labels.html that was causing 404 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the “Prism Account Sources” hyperlink in the printable documentation to point to the proper labels page.
  - Improves navigation and reduces confusion for readers accessing related content.
  - No changes to application behavior, APIs, or runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->