### PR TITLE
feat: start_height/allow_mock_proof cli args

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,11 +52,16 @@ Prism is a high-performance key transparency solution written in Rust, creating 
 - Include tests for new functionality
 - Error handling: Use Result types with descriptive error messages
 - Naming: follow Rust conventions (snake_case for functions/variables, CamelCase for types)
-- Documentation: Add comments for public APIs and complex logic
 - File organization: Group related functionality in modules
 
+### Documentation
+- Add comments mostly for public APIs that are exposed on crate level
+- Only add comments for private APIs when they are complex or have non-obvious behavior
+- Keep public method docstrings short and focused (e.g. very short summary, very short explanation of parameters & return value)
+- If necessary, use longer examples only in module files (mod.rs or lib.rs)
+
 ### Testing
-- Do not write tests for derived traits (Clone, Debug, PartialEq, etc), unless there's a custom implementation for them
+- Do not write tests for derived traits (Clone, Debug, PartialEq, Serialize, Deserialize, etc), unless there's a custom implementation for them
 
 ### Commits
 - Always combine related changes in focused, granular commits

--- a/clippy.toml
+++ b/clippy.toml
@@ -4,4 +4,5 @@ doc-valid-idents = [
   "WebSocket",
   "OpenTelemetry",
   "IndexedDB",
+  "CloudWatch",
 ]

--- a/crates/cli/src/apply_args/commands.rs
+++ b/crates/cli/src/apply_args/commands.rs
@@ -38,6 +38,10 @@ impl CliOverridableConfig<FullNodePreset> for CliFullNodeConfig {
             self.full_node.verifying_key_str = verifying_key_str.clone();
         }
 
+        if let Some(start_height) = args.start_height {
+            self.full_node.start_height = start_height;
+        }
+
         Ok(())
     }
 }
@@ -56,6 +60,10 @@ impl CliOverridableConfig<ProverPreset> for CliProverConfig {
 
         if let Some(max_epochless_gap) = args.max_epochless_gap {
             self.prover.max_epochless_gap = max_epochless_gap;
+        }
+
+        if let Some(start_height) = args.start_height {
+            self.prover.start_height = start_height;
         }
 
         if let Some(recursive_proofs) = args.recursive_proofs {

--- a/crates/cli/src/cli_args/commands.rs
+++ b/crates/cli/src/cli_args/commands.rs
@@ -21,7 +21,11 @@ pub enum CliCommands {
 
 #[derive(Args, Deserialize, Clone, Debug)]
 pub struct LightClientCliArgs {
-    #[arg(long)]
+    #[arg(long, conflicts_with = "specter")]
+    /// Start light client in development mode
+    pub dev: bool,
+
+    #[arg(long, conflicts_with = "dev")]
     /// Start light client with connection to specter testnet
     pub specter: bool,
 
@@ -46,7 +50,13 @@ impl CliArgs for LightClientCliArgs {
     }
 
     fn preset(&self) -> Option<LightClientPreset> {
-        self.specter.then_some(LightClientPreset::Specter)
+        if self.dev {
+            Some(LightClientPreset::Development)
+        } else if self.specter {
+            Some(LightClientPreset::Specter)
+        } else {
+            None
+        }
     }
 }
 

--- a/crates/cli/src/cli_args/commands.rs
+++ b/crates/cli/src/cli_args/commands.rs
@@ -78,6 +78,11 @@ pub struct FullNodeCliArgs {
     /// base64-encoded SPKI DER content directly.
     pub verifying_key: Option<String>,
 
+    #[arg(long)]
+    /// The height of the first prism block to consider
+    /// Default: 1
+    pub start_height: Option<u64>,
+
     #[command(flatten)]
     pub da: CliDaLayerArgs,
 
@@ -127,6 +132,11 @@ pub struct ProverCliArgs {
     #[arg(long)]
     /// Maximum number of epochs allowed without proofs before triggering action
     pub max_epochless_gap: Option<u64>,
+
+    #[arg(long)]
+    /// The height of the first prism block to consider
+    /// Default: 1
+    pub start_height: Option<u64>,
 
     #[arg(long)]
     /// Enable recursive proofs for more efficient verification

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -56,11 +56,12 @@ async fn run_cli() -> Result<(), CliError> {
                 CliError::ConfigFailed(format!("Error loading light client config: {}", e))
             })?;
 
-            let da = create_light_client_da_layer(&config.da).await?;
             let telemetry = create_telemetry(
                 &config.telemetry,
                 vec![("node_type".to_string(), "lightclient".to_string())],
             )?;
+
+            let da = create_light_client_da_layer(&config.da).await?;
 
             let light_client =
                 create_light_client(da, &config.light_client, cancellation_token.clone()).map_err(
@@ -73,12 +74,13 @@ async fn run_cli() -> Result<(), CliError> {
                 CliError::ConfigFailed(format!("Error loading prover config: {}", e))
             })?;
 
-            let db = create_storage(&config.db).await?;
-            let da = create_full_node_da_layer(&config.da).await?;
             let telemetry = create_telemetry(
                 &config.telemetry,
                 vec![("node_type".to_string(), "prover".to_string())],
             )?;
+
+            let db = create_storage(&config.db).await?;
+            let da = create_full_node_da_layer(&config.da).await?;
 
             let prover = create_prover_as_prover(
                 &config.prover,

--- a/crates/da/src/celestia/light_client.rs
+++ b/crates/da/src/celestia/light_client.rs
@@ -11,7 +11,7 @@ use tracing::{trace, warn};
 
 #[cfg(target_arch = "wasm32")]
 use lumina_node::{blockstore::IndexedDbBlockstore, store::IndexedDbStore};
-use prism_presets::{ApplyPreset, LightClientPreset, PresetError};
+use prism_presets::PresetError;
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationSeconds, serde_as};
 #[cfg(not(target_arch = "wasm32"))]
@@ -235,14 +235,16 @@ impl Default for CelestiaLightClientDAConfig {
     }
 }
 
-impl ApplyPreset<LightClientPreset> for CelestiaLightClientDAConfig {
-    fn apply_preset(&mut self, preset: &LightClientPreset) -> Result<(), PresetError> {
-        match preset {
-            LightClientPreset::Specter => {
-                self.celestia_network = CelestiaNetwork::Mocha;
-                self.snark_namespace_id = DEVNET_SPECTER_SNARK_NAMESPACE_ID.to_string();
-            }
-        }
+impl CelestiaLightClientDAConfig {
+    pub fn new_for_specter() -> std::result::Result<Self, PresetError> {
+        let mut config = Self::default();
+        config.apply_specter_preset()?;
+        Ok(config)
+    }
+
+    pub fn apply_specter_preset(&mut self) -> std::result::Result<(), PresetError> {
+        self.celestia_network = CelestiaNetwork::Mocha;
+        self.snark_namespace_id = DEVNET_SPECTER_SNARK_NAMESPACE_ID.to_string();
         Ok(())
     }
 }

--- a/crates/da/src/factory.rs
+++ b/crates/da/src/factory.rs
@@ -63,14 +63,17 @@ impl LightClientDAConfig {
 impl ApplyPreset<LightClientPreset> for LightClientDAConfig {
     fn apply_preset(&mut self, preset: &LightClientPreset) -> Result<(), PresetError> {
         match preset {
+            LightClientPreset::Development => {
+                // Nothing to change for DA in development preset
+                Ok(())
+            }
             LightClientPreset::Specter => {
                 // When applying specter preset, we need to use celestia
                 // If it is not set, apply preset on default celestia config
                 if let Self::Celestia(celestia_config) = self {
-                    celestia_config.apply_preset(preset)
+                    celestia_config.apply_specter_preset()
                 } else {
-                    *self =
-                        Self::Celestia(CelestiaLightClientDAConfig::default_with_preset(preset)?);
+                    *self = Self::Celestia(CelestiaLightClientDAConfig::new_for_specter()?);
                     Ok(())
                 }
             }

--- a/crates/node_types/prover/src/factory.rs
+++ b/crates/node_types/prover/src/factory.rs
@@ -77,7 +77,7 @@ pub struct ProverConfig {
     /// Path to the signing key file for generating proofs.
     /// If the file doesn't exist, a new key pair will be generated automatically.
     /// The private key must be kept secure as it signs SNARK proofs.
-    /// Default: `~/.prism/prover_key.pk8`
+    /// Default: `~/.prism/prover_key.p8`
     pub signing_key_path: String,
 
     /// Height of the first block with prism information.

--- a/crates/node_types/prover/src/factory.rs
+++ b/crates/node_types/prover/src/factory.rs
@@ -35,6 +35,10 @@ pub struct FullNodeConfig {
     #[serde(rename = "verifying_key")]
     pub verifying_key_str: String,
 
+    /// Height of the first block with prism information.
+    /// Default: 1
+    pub start_height: u64,
+
     /// Web server configuration for REST API endpoints.
     pub webserver: WebServerConfig,
 }
@@ -48,6 +52,7 @@ impl Default for FullNodeConfig {
                 .join(".prism/prover_key.spki")
                 .to_string_lossy()
                 .into_owned(),
+            start_height: 1,
             webserver: WebServerConfig::default(),
         }
     }
@@ -75,6 +80,10 @@ pub struct ProverConfig {
     /// Default: `~/.prism/prover_key.pk8`
     pub signing_key_path: String,
 
+    /// Height of the first block with prism information.
+    /// Default: 1
+    pub start_height: u64,
+
     /// Maximum number of epochs without generating a proof before forcing one.
     /// Lower values provide faster finality but increase computational overhead.
     pub max_epochless_gap: u64,
@@ -94,11 +103,12 @@ impl Default for ProverConfig {
             signing_key_path: dirs::home_dir()
                 .or_else(|| env::current_dir().ok())
                 .unwrap_or_else(|| PathBuf::from("."))
-                .join(".prism/prover_key.pk8")
+                .join(".prism/prover_key.p8")
                 .to_string_lossy()
                 .into_owned(),
             max_epochless_gap: DEFAULT_MAX_EPOCHLESS_GAP,
             recursive_proofs: true,
+            start_height: 1,
             webserver: WebServerConfig::default(),
         }
     }
@@ -130,7 +140,7 @@ pub fn create_prover_as_full_node(
     let prover_opts = ProverOptions {
         syncer: SyncerOptions {
             verifying_key,
-            start_height: 1,
+            start_height: config.start_height,
             max_epochless_gap: DEFAULT_MAX_EPOCHLESS_GAP,
             prover_enabled: false,
         },
@@ -175,7 +185,7 @@ pub fn create_prover_as_prover(
     let prover_opts = ProverOptions {
         syncer: SyncerOptions {
             verifying_key: signing_key.verifying_key(),
-            start_height: 1,
+            start_height: config.start_height,
             max_epochless_gap: config.max_epochless_gap,
             prover_enabled: true,
         },
@@ -248,7 +258,7 @@ mod tests {
     fn test_prover_config_default() {
         let config = ProverConfig::default();
 
-        assert!(config.signing_key_path.contains(".prism/prover_key.pk8"));
+        assert!(config.signing_key_path.contains(".prism/prover_key.p8"));
         assert_eq!(config.max_epochless_gap, DEFAULT_MAX_EPOCHLESS_GAP);
         assert!(config.recursive_proofs);
         assert_eq!(config.webserver, WebServerConfig::default());
@@ -277,7 +287,7 @@ mod tests {
     fn test_create_prover_as_full_node() {
         let config = FullNodeConfig {
             verifying_key_str: PRESET_SPECTER_PUBLIC_KEY_BASE64.to_string(),
-            webserver: WebServerConfig::default(),
+            ..FullNodeConfig::default()
         };
 
         let db = Arc::new(Box::new(InMemoryDatabase::new()) as Box<dyn Database>);
@@ -293,7 +303,7 @@ mod tests {
     fn test_create_prover_as_full_node_with_invalid_key() {
         let config = FullNodeConfig {
             verifying_key_str: "invalid_key".to_string(),
-            webserver: WebServerConfig::default(),
+            ..FullNodeConfig::default()
         };
 
         let db = Arc::new(Box::new(InMemoryDatabase::new()) as Box<dyn Database>);
@@ -308,7 +318,7 @@ mod tests {
     #[test]
     fn test_create_prover_as_prover_with_existing_key() {
         let temp_dir = TempDir::new().unwrap();
-        let signing_key_path = temp_dir.path().join("test_key.pk8");
+        let signing_key_path = temp_dir.path().join("test_key.p8");
 
         // Create a key pair first
         let signing_key = SigningKey::new_ed25519();
@@ -316,9 +326,7 @@ mod tests {
 
         let config = ProverConfig {
             signing_key_path: signing_key_path.to_string_lossy().to_string(),
-            max_epochless_gap: DEFAULT_MAX_EPOCHLESS_GAP,
-            recursive_proofs: true,
-            webserver: WebServerConfig::default(),
+            ..ProverConfig::default()
         };
 
         let db = Arc::new(Box::new(InMemoryDatabase::new()) as Box<dyn Database>);
@@ -333,13 +341,11 @@ mod tests {
     #[test]
     fn test_create_prover_as_prover_generates_new_key() {
         let temp_dir = TempDir::new().unwrap();
-        let signing_key_path = temp_dir.path().join("new_key.pk8");
+        let signing_key_path = temp_dir.path().join("new_key.p8");
 
         let config = ProverConfig {
             signing_key_path: signing_key_path.to_string_lossy().to_string(),
-            max_epochless_gap: DEFAULT_MAX_EPOCHLESS_GAP,
-            recursive_proofs: true,
-            webserver: WebServerConfig::default(),
+            ..ProverConfig::default()
         };
 
         let db = Arc::new(Box::new(InMemoryDatabase::new()) as Box<dyn Database>);
@@ -359,11 +365,13 @@ mod tests {
     fn test_full_node_config_clone() {
         let config = FullNodeConfig {
             verifying_key_str: "test_key".to_string(),
+            start_height: 10,
             webserver: WebServerConfig::default(),
         };
 
         let cloned = config.clone();
         assert_eq!(config.verifying_key_str, cloned.verifying_key_str);
+        assert_eq!(config.start_height, cloned.start_height);
     }
 
     #[test]
@@ -372,6 +380,7 @@ mod tests {
             signing_key_path: "test_path".to_string(),
             max_epochless_gap: 100,
             recursive_proofs: false,
+            start_height: 10,
             webserver: WebServerConfig::default(),
         };
 
@@ -379,31 +388,6 @@ mod tests {
         assert_eq!(config.signing_key_path, cloned.signing_key_path);
         assert_eq!(config.max_epochless_gap, cloned.max_epochless_gap);
         assert_eq!(config.recursive_proofs, cloned.recursive_proofs);
-    }
-
-    #[test]
-    fn test_full_node_config_debug() {
-        let config = FullNodeConfig {
-            verifying_key_str: "test_key".to_string(),
-            webserver: WebServerConfig::default(),
-        };
-
-        let debug_str = format!("{:?}", config);
-        assert!(debug_str.contains("test_key"));
-    }
-
-    #[test]
-    fn test_prover_config_debug() {
-        let config = ProverConfig {
-            signing_key_path: "test_path".to_string(),
-            max_epochless_gap: 100,
-            recursive_proofs: false,
-            webserver: WebServerConfig::default(),
-        };
-
-        let debug_str = format!("{:?}", config);
-        assert!(debug_str.contains("test_path"));
-        assert!(debug_str.contains("100"));
-        assert!(debug_str.contains("false"));
+        assert_eq!(config.start_height, cloned.start_height);
     }
 }

--- a/crates/node_types/prover/src/lib.rs
+++ b/crates/node_types/prover/src/lib.rs
@@ -58,7 +58,8 @@
 //!
 //!     // Configure the prover
 //!     let prover_config = ProverConfig {
-//!         signing_key_path: "/secure/keys/prover.pk8".to_string(),
+//!         signing_key_path: "/secure/keys/prover.p8".to_string(),
+//!         start_height: 1,
 //!         max_epochless_gap: 1000,        // Less frequent proofs
 //!         recursive_proofs: true,         // Production mode
 //!         webserver: WebServerConfig {

--- a/crates/node_types/prover/src/prover/mod.rs
+++ b/crates/node_types/prover/src/prover/mod.rs
@@ -175,7 +175,7 @@ impl Prover {
             latest_epoch_da_height.clone(),
             sequencer.clone(),
             prover_engine.clone(),
-        ));
+        )?);
 
         Ok(Self {
             options: opts.clone(),

--- a/crates/node_types/prover/src/syncer.rs
+++ b/crates/node_types/prover/src/syncer.rs
@@ -34,10 +34,14 @@ impl Syncer {
         latest_epoch_da_height: Arc<RwLock<u64>>,
         sequencer: Arc<Sequencer>,
         prover_engine: Arc<dyn ProverEngine>,
-    ) -> Self {
+    ) -> Result<Self> {
+        if config.start_height == 0 {
+            return Err(anyhow!("Start height must be >= 1"));
+        }
+
         let event_pub = Arc::new(da.event_channel().publisher());
 
-        Self {
+        Ok(Self {
             da,
             db,
             tx_buffer: Arc::new(RwLock::new(TxBuffer::new())),
@@ -49,7 +53,7 @@ impl Syncer {
             prover_engine,
             event_pub,
             is_prover_enabled: config.prover_enabled,
-        }
+        })
     }
 
     pub fn get_da(&self) -> Arc<dyn DataAvailabilityLayer> {

--- a/crates/presets/src/lib.rs
+++ b/crates/presets/src/lib.rs
@@ -7,6 +7,7 @@ pub const PRESET_SPECTER_PUBLIC_KEY_BASE64: &str =
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum LightClientPreset {
+    Development,
     Specter,
 }
 
@@ -15,6 +16,7 @@ impl FromStr for LightClientPreset {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
+            "development" | "dev" => Ok(LightClientPreset::Development),
             "specter" => Ok(LightClientPreset::Specter),
             _ => Err(PresetError::UnknownPreset(format!(
                 "Unknown LightClientPreset: {}",

--- a/crates/serde/src/binary.rs
+++ b/crates/serde/src/binary.rs
@@ -1,8 +1,10 @@
+use std::fmt::Display;
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 pub trait ToBinary {
-    type Error;
+    type Error: Display;
 
     fn encode_to_bytes(&self) -> Result<Vec<u8>, Self::Error>;
 }
@@ -19,7 +21,7 @@ where
 }
 
 pub trait FromBinary: Sized {
-    type Error;
+    type Error: Display;
 
     fn decode_from_bytes<B: AsRef<[u8]>>(bytes: B) -> Result<Self, Self::Error>;
 }

--- a/crates/serde/src/binary.rs
+++ b/crates/serde/src/binary.rs
@@ -1,7 +1,5 @@
-use std::fmt::Display;
-
-use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 pub trait ToBinary {
     type Error: Display;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added --dev preset for light clients (development mode) and mock-proof option for easier testing.
  - Added start-height support for Full Node and Prover via CLI/config, with PRISM__START_HEIGHT env override and clear precedence rules.

- Bug Fixes
  - Validation prevents invalid start-height (must be >= 1), causing startup errors for bad values.

- Improvements
  - Telemetry initialized earlier for more reliable startup.

- Documentation
  - New documentation guidelines and updated examples (key file extension switched to .p8).

- Chores
  - Lint config expanded to recognize additional identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->