### PR TITLE
feat: AWS DA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Prism is a high-performance key transparency solution written in Rust, creating 
 - Use conventional commits
 - Allowed types are feat, refactor, fix, build, ci, chore, docs, test, release
 - Use canonical crate names as scopes for conventional commits (e.g. lightclient, prover, keys, da, etc..)
+- Use build for commits that update dependencies
 - Do not mention AI in the description
 - If updated, always make a separate commit "chore: update zkVM ELF and keys" for keys.json and elf files as last commit
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7551,6 +7551,7 @@ dependencies = [
  "sp1-verifier",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-util",
  "tracing",
  "wasm-bindgen-futures",
 ]
@@ -7572,6 +7573,7 @@ dependencies = [
  "prism-common",
  "serde",
  "tokio",
+ "tokio-util",
  "tracing",
  "wasm-bindgen-futures",
  "web-time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "k256",
  "thiserror 2.0.12",
 ]
@@ -377,7 +377,7 @@ dependencies = [
  "async-trait",
  "aws-sdk-kms",
  "k256",
- "spki",
+ "spki 0.7.3",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -1009,6 +1009,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -1044,6 +1045,40 @@ dependencies = [
  "http 0.2.12",
  "regex-lite",
  "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af040a86ae4378b7ed2f62c83b36be1848709bbbf5757ec850d0e08596a26be9"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.10.8",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1120,19 +1155,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084c34162187d39e3740cb635acd73c4e3a551a36146ad6fe8883c929c9f876c"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
+ "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
+ "p256 0.11.1",
  "percent-encoding",
+ "ring 0.17.14",
  "sha2 0.10.8",
+ "subtle",
  "time",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -1147,11 +1188,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-checksums"
+version = "0.63.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d2df0314b8e307995a3b86d44565dfe9de41f876901a7d71886c756a25979f"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.8",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "182b03393e8c677347fb5705a04a9392695d47d20ef0a2f8cfe28c8e6b9b9778"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.62.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c4dacf2d38996cf729f55e7a762b30918229917eca115de45dfa8dfb97796c9"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -1457,6 +1530,12 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -2444,6 +2523,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "libc",
+ "rand 0.9.1",
+ "regex",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2583,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -2752,6 +2856,16 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
@@ -3004,16 +3118,28 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
  "serdect",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3022,8 +3148,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3072,21 +3198,41 @@ checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array 0.14.7",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
  "ff 0.13.1",
  "generic-array 0.14.7",
  "group 0.13.0",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
  "serdect",
  "subtle",
  "zeroize",
@@ -4860,13 +5006,13 @@ version = "0.13.4"
 source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-k256-13.4-sp1-5.0.0#f7d8998e05d8cbcbd8e543eba1030a7385011fa8"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "hex",
  "once_cell",
  "serdect",
  "sha2 0.10.8",
- "signature",
+ "signature 2.2.0",
  "sp1-lib",
 ]
 
@@ -5778,6 +5924,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6546,11 +6702,22 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "p256"
 version = "0.13.2"
 source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-5.0.0#10cca2ef98bebbad35e2475849433fc3e75e27d9"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "hex",
  "primeorder",
  "serdect",
@@ -7052,12 +7219,22 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -7270,7 +7447,7 @@ name = "primeorder"
 version = "0.13.1"
 source = "git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-5.0.0#10cca2ef98bebbad35e2475849433fc3e75e27d9"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "serdect",
 ]
 
@@ -7348,11 +7525,15 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-config",
+ "aws-sdk-s3",
+ "aws-sdk-sts",
  "bincode",
  "blockstore",
  "celestia-rpc",
  "celestia-types",
  "dirs 6.0.0",
+ "futures",
  "libp2p",
  "lumina-node",
  "mockall",
@@ -7364,11 +7545,14 @@ dependencies = [
  "prism-serde",
  "redb",
  "serde",
+ "serde_json",
  "serde_with",
  "sp1-sdk",
  "sp1-verifier",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -7402,8 +7586,8 @@ dependencies = [
  "ed25519-consensus",
  "getrandom 0.2.16",
  "k256",
- "p256",
- "pkcs8",
+ "p256 0.13.2",
+ "pkcs8 0.10.2",
  "prism-serde",
  "rand 0.8.5",
  "ripemd",
@@ -8319,6 +8503,17 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
+name = "rfc6979"
 version = "0.4.0"
 source = "git+https://github.com/sp1-patches/signatures.git?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
@@ -8878,14 +9073,28 @@ checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array 0.14.7",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array 0.14.7",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serdect",
  "subtle",
  "zeroize",
@@ -9122,7 +9331,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "serde",
 ]
 
@@ -9227,6 +9436,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9393,7 +9612,7 @@ dependencies = [
  "cbindgen",
  "cc",
  "cfg-if",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "generic-array 1.1.0",
  "glob",
  "hashbrown 0.14.5",
@@ -9402,7 +9621,7 @@ dependencies = [
  "k256",
  "num",
  "num_cpus",
- "p256",
+ "p256 0.13.2",
  "p3-air",
  "p3-baby-bear",
  "p3-challenger",
@@ -9464,12 +9683,12 @@ checksum = "69234f4667ae1a00f7bfb90b42d6aa141744114b128ac262b9a28e9c869cf514"
 dependencies = [
  "cfg-if",
  "dashu",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "generic-array 1.1.0",
  "itertools 0.13.0",
  "k256",
  "num",
- "p256",
+ "p256 0.13.2",
  "p3-field",
  "serde",
  "snowbridge-amcl",
@@ -9495,7 +9714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e1fe81b6f87134f9170cb642f948ae41e0ee1cd3785e0cb665add5b67106d1a"
 dependencies = [
  "bincode",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "serde",
  "sp1-primitives",
 ]
@@ -9855,12 +10074,22 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -10120,7 +10349,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha2 0.10.8",
- "signature",
+ "signature 2.2.0",
  "subtle",
  "subtle-encoding",
  "tendermint-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7545,7 +7545,6 @@ dependencies = [
  "prism-serde",
  "redb",
  "serde",
- "serde_json",
  "serde_with",
  "sp1-sdk",
  "sp1-verifier",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,12 @@ celestia-rpc = { git = "https://github.com/deltadevsde/lumina.git" }
 celestia-types = { git = "https://github.com/deltadevsde/lumina.git" }
 lumina-node = { git = "https://github.com/deltadevsde/lumina.git" }
 
+# aws
+aws-config = { version = "1.6.2" }
+aws-sdk-s3 = { version = "1.83.0" }
+aws-sdk-sts = { version = "1.82.0" }
+aws-smithy-types = { version = "1.2.16" }
+
 # p2p
 libp2p = "0.54.1"
 
@@ -139,6 +145,7 @@ jmt = { git = "https://github.com/deltadevsde/jmt", branch = "rehashing-circuit"
 sha2 = "0.10.8"
 auto_impl = "1.2.0"
 paste = "1.0.15"
+backon = "1.5.2"
 
 # plotting
 plotters = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,6 @@ lumina-node = { git = "https://github.com/deltadevsde/lumina.git" }
 aws-config = { version = "1.6.2" }
 aws-sdk-s3 = { version = "1.83.0" }
 aws-sdk-sts = { version = "1.82.0" }
-aws-smithy-types = { version = "1.2.16" }
 
 # p2p
 libp2p = "0.54.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,6 @@ jmt = { git = "https://github.com/deltadevsde/jmt", branch = "rehashing-circuit"
 sha2 = "0.10.8"
 auto_impl = "1.2.0"
 paste = "1.0.15"
-backon = "1.5.2"
 
 # plotting
 plotters = "0.3.7"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 Prism is a decentralized key transparency protocol, first inspired by the paper [Tzialla et. al](https://eprint.iacr.org/2021/1263.pdf), leveraging zkSNARKs and DA solutions to enable trust-minimized verification of E2EE services via WASM/Native light clients. This eliminates the possibility for hidden backdoors in E2EE services through a user-verifiable key management system. It uses transparency dictionaries under the hood, offering a generalized solution for managing a label-value map in environments where the service maintaining the map is not completely trusted.
 
-Prism provides the first key-transparency solution to enable automatic verification of the service provider. This is achieved by providing constant size succinct proofs to WASM/Native light clients over a [data availability layer](https://arxiv.org/abs/1809.09044). Alternative DA solutions are in planning, allowing for a less trust-minimized client where a p2p node cannot be embedded.
+Prism provides the first key-transparency solution to enable automatic verification of the service provider. This is achieved by providing constant size succinct proofs to WASM/Native light clients over a [data availability layer](https://arxiv.org/abs/1809.09044). Multiple DA backends are supported including Celestia for decentralized availability.
 
 The system is designed to be efficient, scalable and secure, making it suitable for a wide range of applications.
 

--- a/crates/cli/src/apply_args/commands.rs
+++ b/crates/cli/src/apply_args/commands.rs
@@ -22,6 +22,10 @@ impl CliOverridableConfig<LightClientPreset> for CliLightClientConfig {
             self.light_client.verifying_key_str = verifying_key_str.clone();
         }
 
+        if let Some(allow_mock_proofs) = args.allow_mock_proofs {
+            self.light_client.allow_mock_proofs = allow_mock_proofs;
+        }
+
         Ok(())
     }
 }

--- a/crates/cli/src/cli_args/commands.rs
+++ b/crates/cli/src/cli_args/commands.rs
@@ -38,6 +38,11 @@ pub struct LightClientCliArgs {
     /// base64-encoded SPKI DER content directly.
     pub verifying_key: Option<String>,
 
+    #[arg(long)]
+    /// Whether to allow the verification of mock proofs
+    /// Default: false
+    pub allow_mock_proofs: Option<bool>,
+
     #[command(flatten)]
     pub da: CliDaLayerArgs,
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,7 +61,7 @@ async fn run_cli() -> Result<(), CliError> {
                 vec![("node_type".to_string(), "lightclient".to_string())],
             )?;
 
-            let da = create_light_client_da_layer(&config.da).await?;
+            let da = create_light_client_da_layer(&config.da, cancellation_token.clone()).await?;
 
             let light_client =
                 create_light_client(da, &config.light_client, cancellation_token.clone()).map_err(
@@ -80,7 +80,7 @@ async fn run_cli() -> Result<(), CliError> {
             )?;
 
             let db = create_storage(&config.db).await?;
-            let da = create_full_node_da_layer(&config.da).await?;
+            let da = create_full_node_da_layer(&config.da, cancellation_token.clone()).await?;
 
             let prover = create_prover_as_prover(
                 &config.prover,
@@ -98,7 +98,7 @@ async fn run_cli() -> Result<(), CliError> {
             })?;
 
             let db = create_storage(&config.db).await?;
-            let da = create_full_node_da_layer(&config.da).await?;
+            let da = create_full_node_da_layer(&config.da, cancellation_token.clone()).await?;
             let telemetry = create_telemetry(
                 &config.telemetry,
                 vec![("node_type".to_string(), "fullnode".to_string())],

--- a/crates/cli/src/tests/mod.rs
+++ b/crates/cli/src/tests/mod.rs
@@ -47,6 +47,7 @@ verifying_key_str = "config_file_key"
         specter: false,
         config_path,
         verifying_key: Some("cli_key".to_string()),
+        allow_mock_proofs: Some(true),
         da: Default::default(),
     };
 
@@ -54,6 +55,7 @@ verifying_key_str = "config_file_key"
 
     // CLI args should take precedence
     assert_eq!(config.light_client.verifying_key_str, "cli_key");
+    assert!(config.light_client.allow_mock_proofs);
 
     clear_env_vars();
     Ok(())
@@ -71,12 +73,14 @@ verifying_key = "config_file_key"
 
     // Set environment variable
     unsafe { env::set_var("PRISM__VERIFYING_KEY", "env_key") };
+    unsafe { env::set_var("PRISM__ALLOW_MOCK_PROOFS", "true") };
 
     let cli_args = LightClientCliArgs {
         dev: false,
         specter: false,
         config_path,
         verifying_key: None, // No CLI override
+        allow_mock_proofs: None,
         da: Default::default(),
     };
 
@@ -84,6 +88,7 @@ verifying_key = "config_file_key"
 
     // Environment should override file
     assert_eq!(config.light_client.verifying_key_str, "env_key");
+    assert!(config.light_client.allow_mock_proofs);
 
     clear_env_vars();
     Ok(())
@@ -99,12 +104,14 @@ fn test_config_loading_with_missing_file() -> Result<()> {
         specter: false,
         config_path: "/non/existent/path.toml".to_string(),
         verifying_key: Some("cli_key".to_string()),
+        allow_mock_proofs: None,
         da: Default::default(),
     };
 
     // Should not fail and use defaults with CLI overrides
     let config = CliLightClientConfig::load(&cli_args)?;
     assert_eq!(config.light_client.verifying_key_str, "cli_key");
+    assert!(!config.light_client.allow_mock_proofs);
 
     Ok(())
 }
@@ -121,6 +128,7 @@ fn test_light_client_preset_application() -> Result<()> {
         specter: true,
         config_path,
         verifying_key: None,
+        allow_mock_proofs: None,
         da: Default::default(),
     };
 

--- a/crates/da/Cargo.toml
+++ b/crates/da/Cargo.toml
@@ -9,17 +9,23 @@ repository.workspace = true
 license.workspace = true
 keywords.workspace = true
 readme.workspace = true
-
 [features]
 default = []
+aws = ["dep:aws-config", "dep:aws-sdk-s3", "dep:aws-sdk-sts", "dep:futures"]
 
 [dependencies]
+aws-config = { workspace = true, optional = true }
+aws-sdk-s3 = { workspace = true, optional = true }
+aws-sdk-sts = { workspace = true, optional = true }
 blockstore = { workspace = true }
+futures = { workspace = true, optional = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 serde_with = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
+thiserror = { workspace = true }
 redb = { workspace = true }
 lumina-node = { workspace = true }
 prism-serde = { workspace = true }
@@ -46,6 +52,7 @@ tokio = { workspace = true, default-features = false, features = [
   "sync",
   "time",
 ] }
+wasm-bindgen-futures = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/da/Cargo.toml
+++ b/crates/da/Cargo.toml
@@ -14,11 +14,7 @@ default = []
 aws = ["dep:aws-config", "dep:aws-sdk-s3", "dep:aws-sdk-sts", "dep:futures"]
 
 [dependencies]
-aws-config = { workspace = true, optional = true }
-aws-sdk-s3 = { workspace = true, optional = true }
-aws-sdk-sts = { workspace = true, optional = true }
 blockstore = { workspace = true }
-futures = { workspace = true, optional = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -46,6 +42,10 @@ celestia-rpc = { workspace = true }
 sp1-sdk = { workspace = true }
 tokio = { workspace = true }
 blockstore = { workspace = true }
+aws-config = { workspace = true, optional = true }
+aws-sdk-s3 = { workspace = true, optional = true }
+aws-sdk-sts = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true, default-features = false, features = [

--- a/crates/da/Cargo.toml
+++ b/crates/da/Cargo.toml
@@ -17,7 +17,6 @@ aws = ["dep:aws-config", "dep:aws-sdk-s3", "dep:aws-sdk-sts", "dep:futures"]
 blockstore = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 serde_with = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/da/Cargo.toml
+++ b/crates/da/Cargo.toml
@@ -41,6 +41,7 @@ dirs = { workspace = true }
 celestia-rpc = { workspace = true }
 sp1-sdk = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 blockstore = { workspace = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }
@@ -52,6 +53,7 @@ tokio = { workspace = true, default-features = false, features = [
   "sync",
   "time",
 ] }
+tokio-util = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 
 [lints]

--- a/crates/da/src/aws/client.rs
+++ b/crates/da/src/aws/client.rs
@@ -704,7 +704,7 @@ impl AwsDataAvailabilityClient {
     fn epoch_key(&self, height: u64, epoch_index: u64) -> String {
         let padded_height = format!("{:012}", height);
         format!(
-            "{}epochs/{}/epoch{}.bin",
+            "{}epochs/{}/epoch_{}.bin",
             self.key_prefix, padded_height, epoch_index
         )
     }

--- a/crates/da/src/aws/client.rs
+++ b/crates/da/src/aws/client.rs
@@ -1,0 +1,719 @@
+use aws_config::{BehaviorVersion, Region, retry::RetryConfigBuilder};
+use aws_sdk_s3::{
+    Client as S3Client,
+    config::{Credentials, SharedCredentialsProvider},
+    primitives::DateTime,
+    types::{ObjectLockLegalHoldStatus, ObjectLockMode},
+};
+use futures::future::try_join_all;
+use prism_common::transaction::Transaction;
+use prism_errors::DataAvailabilityError;
+use prism_serde::binary::{FromBinary, ToBinary};
+use serde::{Deserialize, Serialize};
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+use tracing::{debug, info, trace, warn};
+
+use crate::{
+    FinalizedEpoch,
+    aws::{AwsCredentialsConfig, AwsFullNodeDAConfig, AwsLightClientDAConfig},
+};
+
+use thiserror::Error;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AwsDaMetaInfo {
+    pub current_height: u64,
+}
+
+#[derive(Error, Debug)]
+pub enum AwsDaClientError {
+    #[error("Failed to initialize AWS client: {0}")]
+    InitializationError(String),
+
+    #[error("Request failed: {0}")]
+    RequestFailed(String),
+
+    #[error("Upload failed: {0}")]
+    UploadFailed(String),
+}
+
+impl From<AwsDaClientError> for DataAvailabilityError {
+    fn from(err: AwsDaClientError) -> Self {
+        match err {
+            AwsDaClientError::InitializationError(msg) => Self::InitializationError(msg),
+            AwsDaClientError::RequestFailed(msg) => Self::NetworkError(msg),
+            AwsDaClientError::UploadFailed(msg) => Self::SubmissionError(msg),
+        }
+    }
+}
+
+/// AWS S3 client facade for data availability operations.
+///
+/// This client handles S3-specific operations including epoch downloading,
+/// height querying, and bucket access management.
+#[derive(Clone)]
+pub struct AwsDataAvailabilityClient {
+    /// S3 client for AWS operations
+    s3_client: S3Client,
+
+    epochs_bucket: String,
+    transactions_bucket: Option<String>,
+    metadata_bucket: String,
+    key_prefix: String,
+    retention_days: u32,
+    enable_legal_holds: bool,
+    max_concurrent_uploads: u32,
+}
+
+impl AwsDataAvailabilityClient {
+    pub async fn new_from_light_da_config(
+        config: AwsLightClientDAConfig,
+    ) -> Result<Self, AwsDaClientError> {
+        // Validate configuration
+        Self::verify_bucket_name(&config.epochs_bucket)?;
+        Self::verify_bucket_name(&config.metadata_bucket)?;
+
+        let s3_client = Self::create_s3_client(
+            config.region.clone(),
+            config.endpoint,
+            config.max_retries,
+            config.max_timeout,
+            &config.credentials,
+        )
+        .await?;
+
+        // Verify bucket access by attempting to list objects
+        Self::verify_bucket_access(&s3_client, &config.epochs_bucket).await?;
+        Self::verify_bucket_access(&s3_client, &config.metadata_bucket).await?;
+
+        // Verify WORM configuration
+        Self::verify_object_lock_enabled(&s3_client, &config.epochs_bucket).await?;
+
+        debug!(
+            "AWS DA client initialized for region '{}', epochs bucket '{}', transactions bucket 'None'",
+            &config.region, &config.epochs_bucket
+        );
+
+        Ok(Self {
+            s3_client,
+            epochs_bucket: config.epochs_bucket,
+            transactions_bucket: None,
+            metadata_bucket: config.metadata_bucket,
+            key_prefix: config.key_prefix,
+            retention_days: 0,
+            enable_legal_holds: false,
+            max_concurrent_uploads: 1,
+        })
+    }
+
+    pub async fn new_from_full_da_config(
+        config: AwsFullNodeDAConfig,
+    ) -> Result<Self, AwsDaClientError> {
+        // Validate configuration
+        Self::verify_bucket_name(&config.light_client.epochs_bucket)?;
+        Self::verify_bucket_name(&config.transactions_bucket)?;
+        Self::verify_bucket_name(&config.light_client.metadata_bucket)?;
+
+        let s3_client = Self::create_s3_client(
+            config.light_client.region.clone(),
+            config.light_client.endpoint,
+            config.light_client.max_retries,
+            config.light_client.max_timeout,
+            &config.light_client.credentials,
+        )
+        .await?;
+
+        // Verify bucket access by attempting to list objects
+        Self::verify_bucket_access(&s3_client, &config.light_client.epochs_bucket).await?;
+        Self::verify_bucket_access(&s3_client, &config.transactions_bucket).await?;
+        Self::verify_bucket_access(&s3_client, &config.light_client.metadata_bucket).await?;
+
+        // Verify WORM configuration
+        Self::verify_object_lock_enabled(&s3_client, &config.light_client.epochs_bucket).await?;
+        Self::verify_object_lock_enabled(&s3_client, &config.transactions_bucket).await?;
+
+        debug!(
+            "AWS DA client initialized for region '{}', epochs bucket '{}', transactions bucket '{}'",
+            &config.light_client.region,
+            &config.light_client.epochs_bucket,
+            &config.transactions_bucket
+        );
+
+        Ok(Self {
+            s3_client,
+            epochs_bucket: config.light_client.epochs_bucket,
+            transactions_bucket: Some(config.transactions_bucket),
+            metadata_bucket: config.light_client.metadata_bucket,
+            key_prefix: config.light_client.key_prefix,
+            retention_days: config.retention_days,
+            enable_legal_holds: config.enable_legal_holds,
+            max_concurrent_uploads: config.max_concurrent_uploads,
+        })
+    }
+
+    /// Gets the highest available epoch height from S3 metadata.
+    pub async fn fetch_height(&self) -> Result<Option<u64>, AwsDaClientError> {
+        let current_height = self.fetch_metadata().await?.map(|info| info.current_height);
+        Ok(current_height)
+    }
+
+    /// Fetches and parses epoch data from S3.
+    pub async fn fetch_epochs(&self, height: u64) -> Result<Vec<FinalizedEpoch>, AwsDaClientError> {
+        let padded_height = format!("{:012}", height);
+        let epochs_path = format!("{}epochs/{}/", self.key_prefix, padded_height);
+
+        self.fetch_all_from_s3(&self.epochs_bucket, &epochs_path).await
+    }
+
+    /// Fetches and parses transaction data from S3.
+    pub async fn fetch_transactions(
+        &self,
+        height: u64,
+    ) -> Result<Vec<Transaction>, AwsDaClientError> {
+        let Some(transactions_bucket) = &self.transactions_bucket else {
+            return Err(AwsDaClientError::InitializationError(
+                "No transactions bucket specified".to_string(),
+            ));
+        };
+
+        trace!("Querying transactions at height {}", height);
+
+        let padded_height = format!("{:012}", height);
+        let transactions_path = format!("{}transactions/{}/", self.key_prefix, padded_height);
+
+        self.fetch_all_from_s3::<Transaction>(transactions_bucket, &transactions_path).await
+    }
+
+    /// Submits transaction data to S3.
+    pub async fn submit_transactions(
+        &self,
+        transactions: Vec<Transaction>,
+        offset: u64,
+        height: u64,
+    ) -> Result<(), AwsDaClientError> {
+        if transactions.is_empty() {
+            return Err(AwsDaClientError::UploadFailed(
+                "No transactions to submit".to_string(),
+            ));
+        }
+
+        let Some(transactions_bucket) = &self.transactions_bucket else {
+            return Err(AwsDaClientError::InitializationError(
+                "No transactions bucket specified".to_string(),
+            ));
+        };
+
+        debug!("Submitting {} transactions to S3", transactions.len());
+
+        // Prepare upload tasks
+        let upload_tasks: Vec<_> = transactions
+            .into_iter()
+            .enumerate()
+            .map(|(index, transaction)| {
+                let index = u64::try_from(index).unwrap();
+                let bucket = transactions_bucket.clone();
+                let key = self.transaction_key(height, offset + index);
+
+                async move { self.upload_with_worm(&bucket, &key, transaction).await }
+            })
+            .collect();
+
+        let max_concurrent_uploads = self.max_concurrent_uploads.try_into().map_err(|e| {
+            AwsDaClientError::UploadFailed(format!(
+                "Failed to convert max concurrent uploads to usize: {}",
+                e
+            ))
+        })?;
+
+        // Execute uploads with concurrency limit
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(max_concurrent_uploads));
+        let upload_futures: Vec<_> = upload_tasks
+            .into_iter()
+            .map(|task| {
+                let sem = semaphore.clone();
+                async move {
+                    let _permit = sem.acquire().await.unwrap();
+                    task.await
+                }
+            })
+            .collect();
+        let upload_futures_count = upload_futures.len();
+
+        try_join_all(upload_futures).await.map_err(|e| {
+            AwsDaClientError::UploadFailed(format!("Failed to await all uploads: {}", e))
+        })?;
+
+        info!(
+            "Successfully submitted {} transactions to S3 at height {} with {} day retention",
+            upload_futures_count, height, self.retention_days
+        );
+
+        Ok(())
+    }
+
+    /// Submits a finalized epoch to S3.
+    pub async fn submit_finalized_epoch(
+        &self,
+        epoch: FinalizedEpoch,
+        height: u64,
+    ) -> Result<(), AwsDaClientError> {
+        // TODO: Get latest height or use cached height or transfer it as parameter?
+        let epoch_key = self.epoch_key(height, epoch.height);
+        self.upload_with_worm(&self.epochs_bucket, &epoch_key, epoch).await
+    }
+
+    async fn create_s3_client(
+        region: String,
+        endpoint: Option<String>,
+        max_retries: u32,
+        max_timeout: Duration,
+        credentials: &AwsCredentialsConfig,
+    ) -> Result<S3Client, AwsDaClientError> {
+        let region = Region::new(region);
+        let retry_config =
+            RetryConfigBuilder::new().max_attempts(max_retries).max_backoff(max_timeout).build();
+        let mut config_loader = aws_config::defaults(BehaviorVersion::v2025_01_17())
+            .region(region.clone())
+            .retry_config(retry_config);
+
+        if let Some(endpoint) = endpoint {
+            config_loader = config_loader.endpoint_url(endpoint);
+        }
+
+        match credentials {
+            AwsCredentialsConfig::Default { profile } => {
+                if let Some(profile_name) = profile {
+                    config_loader = config_loader.profile_name(profile_name.clone());
+                }
+                let config = config_loader.load().await;
+                Ok(S3Client::new(&config))
+            }
+            AwsCredentialsConfig::Explicit {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => {
+                let credentials = if let Some(token) = session_token {
+                    Credentials::new(
+                        access_key_id.clone(),
+                        secret_access_key.clone(),
+                        Some(token.clone()),
+                        None,
+                        "prism-explicit",
+                    )
+                } else {
+                    Credentials::new(
+                        access_key_id.clone(),
+                        secret_access_key.clone(),
+                        None,
+                        None,
+                        "prism-explicit",
+                    )
+                };
+
+                let config = config_loader
+                    .credentials_provider(SharedCredentialsProvider::new(credentials))
+                    .load()
+                    .await;
+
+                Ok(S3Client::new(&config))
+            }
+            AwsCredentialsConfig::AssumeRole {
+                role_arn,
+                session_name,
+                external_id,
+                session_duration,
+            } => {
+                // First get base credentials
+                let base_config = aws_config::defaults(BehaviorVersion::v2025_01_17())
+                    .region(region.clone())
+                    .load()
+                    .await;
+
+                let sts_client = aws_sdk_sts::Client::new(&base_config);
+
+                let mut assume_role_request = sts_client
+                    .assume_role()
+                    .role_arn(role_arn.clone())
+                    .role_session_name(session_name.clone())
+                    .duration_seconds(session_duration.as_secs() as i32);
+
+                if let Some(external_id) = external_id {
+                    assume_role_request = assume_role_request.external_id(external_id);
+                }
+
+                let assume_role_response = assume_role_request.send().await.map_err(|e| {
+                    AwsDaClientError::InitializationError(format!(
+                        "Failed to assume role {}: {}",
+                        role_arn, e
+                    ))
+                })?;
+
+                let credentials = assume_role_response.credentials().ok_or_else(|| {
+                    AwsDaClientError::InitializationError(
+                        "No credentials returned from assume role".to_string(),
+                    )
+                })?;
+
+                let aws_credentials = Credentials::new(
+                    credentials.access_key_id(),
+                    credentials.secret_access_key(),
+                    Some(credentials.session_token().to_string()),
+                    Some(credentials.expiration().to_owned().try_into().map_err(|e| {
+                        AwsDaClientError::InitializationError(format!(
+                            "Failed to convert expiration for role {}: {}",
+                            role_arn, e
+                        ))
+                    })?),
+                    "prism-assume-role",
+                );
+
+                let config = config_loader
+                    .credentials_provider(SharedCredentialsProvider::new(aws_credentials))
+                    .load()
+                    .await;
+
+                Ok(S3Client::new(&config))
+            }
+        }
+    }
+
+    /// Verifies that the S3 bucket is accessible with current credentials.
+    async fn verify_bucket_access(client: &S3Client, bucket: &str) -> Result<(), AwsDaClientError> {
+        debug!("Verifying access to S3 bucket '{}'", bucket);
+        client.list_objects_v2().bucket(bucket).max_keys(1).send().await.map_err(|e| {
+            AwsDaClientError::InitializationError(format!(
+                "Cannot access S3 bucket '{}'. Check bucket exists and credentials have s3:ListBucket permission: {}",
+                bucket, e
+            ))
+        })?;
+
+        debug!("Verified access to S3 bucket '{}'", bucket);
+        Ok(())
+    }
+
+    /// Verifies S3 bucket name according to AWS naming rules.
+    fn verify_bucket_name(bucket_name: &str) -> Result<(), AwsDaClientError> {
+        if bucket_name.len() < 3 || bucket_name.len() > 63 {
+            return Err(AwsDaClientError::InitializationError(format!(
+                "Bucket name '{}' must be between 3 and 63 characters",
+                bucket_name
+            )));
+        }
+
+        // Check if bucket name looks like an IP address first (before character validation)
+        if bucket_name
+            .split('.')
+            .map(|part| part.parse::<u8>())
+            .collect::<Result<Vec<_>, _>>()
+            .is_ok()
+            && bucket_name.split('.').count() == 4
+        {
+            return Err(AwsDaClientError::InitializationError(format!(
+                "Bucket name '{}' cannot be formatted as an IP address",
+                bucket_name
+            )));
+        }
+
+        if !bucket_name.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+            return Err(AwsDaClientError::InitializationError(format!(
+                "Bucket name '{}' can only contain lowercase letters, numbers, and hyphens",
+                bucket_name
+            )));
+        }
+
+        if bucket_name.starts_with('-') || bucket_name.ends_with('-') {
+            return Err(AwsDaClientError::InitializationError(format!(
+                "Bucket name '{}' cannot start or end with a hyphen",
+                bucket_name
+            )));
+        }
+
+        if bucket_name.contains("--") {
+            return Err(AwsDaClientError::InitializationError(format!(
+                "Bucket name '{}' cannot contain consecutive hyphens",
+                bucket_name
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn verify_object_lock_enabled(
+        client: &S3Client,
+        bucket: &str,
+    ) -> Result<(), AwsDaClientError> {
+        match client.get_object_lock_configuration().bucket(bucket).send().await {
+            Ok(response) => {
+                if response.object_lock_configuration().is_some() {
+                    debug!("Object Lock confirmed enabled for bucket '{}'", bucket);
+                    Ok(())
+                } else {
+                    Err(AwsDaClientError::InitializationError(format!(
+                        "Bucket '{}' exists but Object Lock is not enabled. WORM compliance requires Object Lock to be enabled at bucket creation.",
+                        bucket
+                    )))
+                }
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                if error_msg.contains("ObjectLockConfigurationNotFoundError") {
+                    Err(AwsDaClientError::InitializationError(format!(
+                        "Bucket '{}' does not have Object Lock enabled. For WORM compliance, Object Lock must be enabled when creating the bucket.",
+                        bucket
+                    )))
+                } else {
+                    Err(AwsDaClientError::InitializationError(format!(
+                        "Cannot verify Object Lock configuration for bucket '{}': {}",
+                        bucket, error_msg
+                    )))
+                }
+            }
+        }
+    }
+
+    /// Generic method to fetch and decode data from S3, handling `NoSuchKey` errors gracefully.
+    async fn fetch_from_s3<T: FromBinary>(
+        &self,
+        bucket: &str,
+        key: &str,
+    ) -> Result<Option<T>, AwsDaClientError> {
+        trace!("Fetching from S3: bucket='{}', key='{}'", bucket, key);
+
+        match self.s3_client.get_object().bucket(bucket).key(key).send().await {
+            Ok(response) => {
+                let body = response.body.collect().await.map_err(|e| {
+                    AwsDaClientError::RequestFailed(format!("Failed to read S3 object body: {}", e))
+                })?;
+
+                let bytes = body.into_bytes();
+
+                trace!("Downloaded {} bytes for key '{}'", bytes.len(), key);
+
+                match T::decode_from_bytes(&bytes) {
+                    Ok(decoded) => {
+                        debug!("Successfully parsed data from S3 key '{}'", key);
+                        Ok(Some(decoded))
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to parse data from S3 key '{}': {}. Data length: {} bytes",
+                            key,
+                            e,
+                            bytes.len()
+                        );
+                        Ok(None)
+                    }
+                }
+            }
+            Err(e) => {
+                // Check if this is a "not found" error
+                let error_string = e.to_string();
+                if error_string.contains("NoSuchKey") || error_string.contains("404") {
+                    trace!("Key '{}' not found in bucket '{}'", key, bucket);
+                    Ok(None)
+                } else {
+                    Err(AwsDaClientError::RequestFailed(format!(
+                        "Failed to get object for key '{}' in bucket '{}': {}",
+                        key, bucket, e
+                    )))
+                }
+            }
+        }
+    }
+
+    async fn fetch_all_from_s3<T: FromBinary>(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Result<Vec<T>, AwsDaClientError> {
+        let objects = self.list_objects_with_prefix(bucket, prefix).await?;
+
+        if objects.is_empty() {
+            debug!("No objects found with prefix '{}'", prefix);
+            return Ok(vec![]);
+        }
+
+        // Download and parse all objects
+        let mut items = Vec::new();
+        for object_key in objects {
+            match self.fetch_from_s3(bucket, &object_key).await {
+                Ok(Some(item)) => items.push(item),
+                Ok(None) => {
+                    warn!("Failed to parse item from object: {}", object_key);
+                }
+                Err(e) => {
+                    warn!("Failed to download object {}: {}", object_key, e);
+                }
+            }
+        }
+
+        debug!("Retrieved {} items with prefix '{}'", items.len(), prefix);
+        Ok(items)
+    }
+
+    /// Fetches metadata from S3, handling `NoSuchKey` errors gracefully.
+    async fn fetch_metadata(&self) -> Result<Option<AwsDaMetaInfo>, AwsDaClientError> {
+        let metadata_key = format!("{}metadata/info.json", self.key_prefix);
+        self.fetch_from_s3(&self.metadata_bucket, &metadata_key).await
+    }
+
+    /// Submits metadata to S3 without WORM compliance.
+    pub async fn submit_metadata(&self, metadata: AwsDaMetaInfo) -> Result<(), AwsDaClientError> {
+        let metadata_key = format!("{}metadata/info.json", self.key_prefix);
+        self.upload(&self.metadata_bucket, &metadata_key, metadata).await
+    }
+
+    /// Uploads metadata without WORM compliance settings.
+    async fn upload<T: ToBinary>(
+        &self,
+        bucket: &str,
+        key: &str,
+        encodable: T,
+    ) -> Result<(), AwsDaClientError> {
+        let object_bytes = encodable.encode_to_bytes().map_err(|e| {
+            AwsDaClientError::UploadFailed(format!("Failed to encode object: {}", e))
+        })?;
+
+        debug!(
+            "Uploading object to S3: {}/{} ({} bytes)",
+            bucket,
+            key,
+            object_bytes.len()
+        );
+
+        self.s3_client
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(object_bytes.into())
+            .send()
+            .await
+            .map_err(|e| {
+                AwsDaClientError::UploadFailed(format!(
+                    "Failed to upload object to S3 bucket '{}' with key '{}': {}",
+                    bucket, key, e
+                ))
+            })?;
+
+        debug!("Successfully uploaded object: {}/{}", bucket, key);
+        Ok(())
+    }
+
+    /// Uploads data with WORM compliance settings.
+    async fn upload_with_worm<T: ToBinary>(
+        &self,
+        bucket: &str,
+        key: &str,
+        encodable: T,
+    ) -> Result<(), AwsDaClientError> {
+        let retain_until = DateTime::from(
+            SystemTime::now() + Duration::from_secs(self.retention_days as u64 * 24 * 3600),
+        );
+        let legal_hold_status = if self.enable_legal_holds {
+            ObjectLockLegalHoldStatus::On
+        } else {
+            ObjectLockLegalHoldStatus::Off
+        };
+
+        let object_bytes = encodable.encode_to_bytes().map_err(|e| {
+            AwsDaClientError::UploadFailed(format!("Failed to encode object: {}", e))
+        })?;
+
+        debug!(
+            "Uploading object to S3: {}/{} ({} bytes)",
+            bucket,
+            key,
+            object_bytes.len()
+        );
+
+        self.s3_client
+            .put_object()
+            .bucket(bucket)
+            .key(key)
+            .body(object_bytes.into())
+            .object_lock_mode(ObjectLockMode::Compliance)
+            .object_lock_retain_until_date(retain_until)
+            .object_lock_legal_hold_status(legal_hold_status)
+            .send()
+            .await
+            .map_err(|e| {
+                AwsDaClientError::UploadFailed(format!(
+                    "Failed to upload object to S3 bucket '{}' with key '{}': {}",
+                    bucket, key, e
+                ))
+            })?;
+
+        debug!(
+            "Successfully uploaded object with WORM: {}/{} with {} day retention",
+            bucket, key, self.retention_days
+        );
+        Ok(())
+    }
+
+    async fn list_objects_with_prefix(
+        &self,
+        bucket: &str,
+        prefix: &str,
+    ) -> Result<Vec<String>, AwsDaClientError> {
+        let mut objects = Vec::new();
+        let mut continuation_token: Option<String> = None;
+
+        loop {
+            let mut request = self.s3_client.list_objects_v2().bucket(bucket).prefix(prefix);
+
+            if let Some(token) = continuation_token.as_ref() {
+                request = request.continuation_token(token);
+            }
+
+            let response = request.send().await.map_err(|e| {
+                AwsDaClientError::InitializationError(format!(
+                    "Failed to list objects in bucket '{}' with prefix '{}': {}",
+                    bucket, prefix, e
+                ))
+            })?;
+
+            if let Some(contents) = &response.contents {
+                for object in contents {
+                    if let Some(key) = object.key() {
+                        objects.push(key.to_string());
+                    }
+                }
+            }
+
+            if response.is_truncated() == Some(true) {
+                continuation_token = response.next_continuation_token().map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
+
+        trace!(
+            "Listed {} objects from bucket '{}' with prefix '{}'",
+            objects.len(),
+            bucket,
+            prefix
+        );
+
+        Ok(objects)
+    }
+
+    fn epoch_key(&self, height: u64, epoch_index: u64) -> String {
+        let padded_height = format!("{:012}", height);
+        format!(
+            "{}epochs/{}/epoch{}.bin",
+            self.key_prefix, padded_height, epoch_index
+        )
+    }
+
+    fn transaction_key(&self, height: u64, tx_index: u64) -> String {
+        let padded_height = format!("{:012}", height);
+        format!(
+            "{}transactions/{}/tx_{}.bin",
+            self.key_prefix, padded_height, tx_index
+        )
+    }
+}

--- a/crates/da/src/aws/config.rs
+++ b/crates/da/src/aws/config.rs
@@ -1,0 +1,740 @@
+use serde::{Deserialize, Serialize};
+use serde_with::{DurationSeconds, serde_as};
+use std::time::Duration;
+
+/// Default S3 region for AWS operations
+pub const DEFAULT_AWS_REGION: &str = "us-east-1";
+
+/// Default timeout for S3 operations
+pub const DEFAULT_S3_MAX_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default maximum retries for S3 operations
+pub const DEFAULT_S3_MAX_RETRIES: u32 = 3;
+
+/// Default retention period for WORM compliance (30 days)
+pub const DEFAULT_RETENTION_DAYS: u32 = 30;
+
+/// Configuration for AWS S3-based data availability layer used by light clients.
+///
+/// Light clients provide read-only access to finalized epochs stored in S3
+/// with WORM (Write Once Read Many) guarantees for data integrity.
+///
+/// # AWS S3 WORM Model
+///
+/// This implementation leverages AWS S3 Object Lock to provide WORM capabilities:
+/// - **Compliance Mode**: Prevents deletion or modification of objects
+/// - **Retention Periods**: Automatically enforced immutability windows
+/// - **Legal Holds**: Additional protection for critical data
+/// - **Versioning**: Maintains object history for audit trails
+///
+/// # Bucket Requirements
+///
+/// The S3 bucket must be configured with:
+/// - Object Lock enabled at bucket creation
+/// - Versioning enabled (required for Object Lock)
+/// - Appropriate IAM permissions for the credentials
+/// - Cross-region replication (recommended for high availability)
+///
+/// # Data Organization
+///
+/// Objects are stored with the following key structure:
+/// - Epochs: `epochs/{height}/epoch.bin`
+/// - Transactions: `transactions/{height}/tx_{index}.bin`
+/// - Metadata: `metadata/{type}/{height}/info.json`
+///
+/// This structure enables efficient queries by height and supports
+/// parallel processing of multiple transactions per block.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AwsLightClientDAConfig {
+    /// AWS region for S3 operations.
+    ///
+    /// Choose a region close to your application for optimal latency.
+    /// Common regions:
+    /// - `us-east-1`: US East (N. Virginia) - Default, lowest latency from many locations
+    /// - `us-west-2`: US West (Oregon) - Good for west coast applications
+    /// - `eu-west-1`: Europe (Ireland) - Good for European applications
+    /// - `ap-northeast-1`: Asia Pacific (Tokyo) - Good for Asian applications
+    pub region: String,
+
+    /// AWS endpoint for S3 operations.
+    ///
+    /// Use this if you need to connect to a custom S3-compatible service.
+    /// Leave empty to use the default AWS S3 endpoint.
+    pub endpoint: Option<String>,
+
+    /// S3 bucket name for storing finalized epochs.
+    ///
+    /// Must be a globally unique bucket name that follows S3 naming conventions:
+    /// - 3-63 characters long
+    /// - Lowercase letters, numbers, and hyphens only
+    /// - Must start and end with lowercase letter or number
+    /// - No consecutive hyphens or periods
+    ///
+    /// Example: "prism-epochs-production-us-east-1"
+    ///
+    /// **Security Note**: Use separate buckets for different environments
+    /// (dev, staging, production) to prevent accidental cross-environment access.
+    pub epochs_bucket: String,
+
+    /// S3 bucket name for storing metadata.
+    ///
+    /// Must be a globally unique bucket name that follows S3 naming conventions:
+    /// - 3-63 characters long
+    /// - Lowercase letters, numbers, and hyphens only
+    /// - Must start and end with lowercase letter or number
+    /// - No consecutive hyphens or periods
+    ///
+    /// Example: "prism-metadata-production-us-east-1"
+    ///
+    /// **Security Note**: Use separate buckets for different environments
+    /// (dev, staging, production) to prevent accidental cross-environment access.
+    pub metadata_bucket: String,
+
+    /// Timeout duration for S3 operations.
+    ///
+    /// This timeout applies to individual S3 API calls including:
+    /// - `GetObject` requests for reading epochs and transactions
+    /// - `ListObjects` requests for discovering available data
+    /// - `HeadObject` requests for checking object metadata
+    ///
+    /// Consider your network conditions and object sizes when setting this value:
+    /// - Local/fast networks: 10-30 seconds
+    /// - Slower networks: 60-120 seconds
+    /// - Large objects: Scale with expected transfer time
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub max_timeout: Duration,
+
+    /// Maximum number of retry attempts for failed S3 operations.
+    ///
+    /// AWS SDK handles exponential backoff automatically, but you can control
+    /// the maximum number of attempts. Higher values provide better reliability
+    /// during transient network issues but may increase latency.
+    ///
+    /// Recommended values:
+    /// - Production: 3-5 retries
+    /// - Development: 1-2 retries
+    /// - CI/Testing: 1 retry to fail fast
+    pub max_retries: u32,
+
+    /// AWS credentials configuration.
+    ///
+    /// Determines how the client authenticates with AWS services.
+    /// The SDK will automatically discover credentials in the following order:
+    /// 1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+    /// 2. AWS credentials file (~/.aws/credentials)
+    /// 3. IAM instance profile (for EC2 instances)
+    /// 4. IAM role for service accounts (for EKS/Kubernetes)
+    /// 5. AWS STS assume role
+    pub credentials: AwsCredentialsConfig,
+
+    /// Optional key prefix for organizing data within buckets.
+    ///
+    /// Useful for:
+    /// - Multi-tenant deployments: `tenant-{id}/`
+    /// - Environment separation: `prod/`, `staging/`, `dev/`
+    /// - Network separation: `mainnet/`, `testnet/`
+    ///
+    /// If specified, all object keys will be prefixed with this value.
+    /// Must end with '/' if you want directory-style organization.
+    ///
+    /// Example: "mainnet/" results in keys like "mainnet/epochs/123/epoch.bin"
+    ///
+    /// Default: ""
+    pub key_prefix: String,
+
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub block_time: Duration,
+}
+
+impl Default for AwsLightClientDAConfig {
+    fn default() -> Self {
+        Self {
+            region: DEFAULT_AWS_REGION.to_string(),
+            endpoint: None,
+            epochs_bucket: "prism-epochs".to_string(),
+            metadata_bucket: "prism-metadata".to_string(),
+            max_timeout: DEFAULT_S3_MAX_TIMEOUT,
+            max_retries: DEFAULT_S3_MAX_RETRIES,
+            credentials: AwsCredentialsConfig::default(),
+            key_prefix: String::new(),
+            block_time: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Configuration for AWS S3-based data availability layer used by full nodes.
+///
+/// Full nodes provide read-write access to both finalized epochs and transaction data
+/// with WORM compliance for published data. This configuration extends the light client
+/// configuration with additional capabilities for data publishing and management.
+///
+/// # Publishing Workflow
+///
+/// Full nodes follow this workflow for publishing data:
+/// 1. **Upload**: Write objects to S3 with temporary keys
+/// 2. **Verify**: Confirm successful upload and data integrity
+/// 3. **Lock**: Apply Object Lock with retention period for WORM compliance
+/// 4. **Notify**: Broadcast availability to network participants
+///
+/// # WORM Compliance Features
+///
+/// - **Retention Periods**: Automatic protection against deletion/modification
+/// - **Legal Holds**: Additional protection for compliance requirements
+/// - **Audit Trails**: Complete history of object access and modifications
+/// - **Cross-Region Replication**: Geographic data distribution for availability
+#[cfg(not(target_arch = "wasm32"))]
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AwsFullNodeDAConfig {
+    /// Light client configuration (inherited).
+    ///
+    /// Full nodes include all light client capabilities plus additional
+    /// features for data publishing and management.
+    #[serde(flatten)]
+    pub light_client: AwsLightClientDAConfig,
+
+    /// S3 bucket name for storing transaction data.
+    ///
+    /// Must follow the same naming conventions as `epochs_bucket`.
+    ///
+    /// Example: "prism-transactions-production-us-east-1"
+    pub transactions_bucket: String,
+
+    /// WORM retention period in days.
+    ///
+    /// Once objects are uploaded, they cannot be deleted or modified
+    /// for this duration. This provides immutability guarantees required
+    /// for blockchain data integrity.
+    ///
+    /// Considerations:
+    /// - **Legal Requirements**: Some jurisdictions require specific retention periods
+    /// - **Storage Costs**: Longer periods increase storage costs
+    /// - **Data Lifecycle**: Align with your data archival policies
+    ///
+    /// Recommended values:
+    /// - Development: 1-7 days
+    /// - Testing: 7-30 days
+    /// - Production: 30-365 days (or more for compliance)
+    pub retention_days: u32,
+
+    /// Enable legal hold feature for critical data protection.
+    ///
+    /// When enabled, objects can have additional legal hold protection
+    /// beyond the retention period. Legal holds:
+    /// - Override retention periods (objects protected until hold is removed)
+    /// - Useful for litigation, audits, or regulatory requirements
+    /// - Can be applied/removed independently of retention periods
+    /// - Provide additional layer of data protection
+    ///
+    /// **Note**: Legal holds may incur additional storage costs and
+    /// require specific IAM permissions to manage.
+    pub enable_legal_holds: bool,
+
+    /// Enable cross-region replication for high availability.
+    ///
+    /// When enabled, data is automatically replicated to a secondary region:
+    /// - **Disaster Recovery**: Protects against regional outages
+    /// - **Performance**: Allows reads from geographically closer regions
+    /// - **Compliance**: Satisfies data residency requirements
+    ///
+    /// **Requirements**:
+    /// - Destination bucket must exist in target region
+    /// - Cross-region replication IAM role must be configured
+    /// - Additional costs for cross-region transfer and storage
+    pub enable_cross_region_replication: bool,
+
+    /// Target region for cross-region replication.
+    ///
+    /// Only used when `enable_cross_region_replication` is true.
+    /// Should be different from the primary region for effective
+    /// disaster recovery coverage.
+    ///
+    /// Consider:
+    /// - **Geographic Distance**: Choose regions far apart for disaster recovery
+    /// - **Latency**: Balance distance with application performance needs
+    /// - **Compliance**: Ensure target region meets regulatory requirements
+    /// - **Costs**: Different regions have different pricing
+    pub replication_region: Option<String>,
+
+    /// Maximum concurrent uploads for batch operations.
+    ///
+    /// When publishing multiple objects (e.g., transaction batches),
+    /// this limits the number of simultaneous S3 uploads to:
+    /// - Prevent overwhelming S3 service limits
+    /// - Control bandwidth usage
+    /// - Manage memory usage for large batches
+    ///
+    /// AWS S3 limits:
+    /// - 3,500 PUT requests per second per prefix
+    /// - Consider your key naming strategy when setting this value
+    ///
+    /// Recommended values:
+    /// - Small instances: 5-10
+    /// - Medium instances: 10-25
+    /// - Large instances: 25-50
+    pub max_concurrent_uploads: u32,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Default for AwsFullNodeDAConfig {
+    fn default() -> Self {
+        Self {
+            light_client: AwsLightClientDAConfig::default(),
+            transactions_bucket: "prism-transactions".to_string(),
+            retention_days: DEFAULT_RETENTION_DAYS,
+            enable_legal_holds: false,
+            enable_cross_region_replication: false,
+            replication_region: None,
+            max_concurrent_uploads: 10,
+        }
+    }
+}
+
+/// AWS credentials configuration options.
+///
+/// Provides flexible authentication methods for different deployment scenarios.
+/// The AWS SDK will attempt authentication in a specific order, and this
+/// configuration allows you to control or override that behavior.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum AwsCredentialsConfig {
+    /// Use AWS SDK's default credential provider chain.
+    ///
+    /// This is the recommended approach for most deployments as it follows
+    /// AWS best practices and works across different environments:
+    ///
+    /// 1. **Environment Variables**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+    ///    `AWS_SESSION_TOKEN`
+    /// 2. **AWS Credentials File**: ~/.aws/credentials (with optional profile)
+    /// 3. **IAM Instance Profile**: For EC2 instances
+    /// 4. **IAM Roles for Service Accounts**: For EKS/Kubernetes
+    /// 5. **AWS STS Assume Role**: For cross-account access
+    ///
+    /// This method is secure, flexible, and follows AWS security best practices.
+    Default {
+        /// Optional AWS profile name to use from credentials file.
+        ///
+        /// If not specified, uses the default profile.
+        /// Useful for:
+        /// - Development environments with multiple AWS accounts
+        /// - Role-based access in shared environments
+        /// - Testing with different permission sets
+        profile: Option<String>,
+    },
+
+    /// Use explicit access keys (NOT RECOMMENDED for production).
+    ///
+    /// **Security Warning**: This method stores credentials in configuration
+    /// files, which poses security risks:
+    /// - Credentials may be logged or exposed in version control
+    /// - No automatic credential rotation
+    /// - Difficult to manage across multiple environments
+    ///
+    /// Only use this for:
+    /// - Local development and testing
+    /// - Environments where IAM roles are not available
+    /// - Temporary setups or proof-of-concepts
+    ///
+    /// **Better Alternatives**:
+    /// - Use environment variables instead of config files
+    /// - Use IAM roles when running on AWS infrastructure
+    /// - Use AWS SSO for development environments
+    Explicit {
+        /// AWS access key ID.
+        access_key_id: String,
+
+        /// AWS secret access key.
+        secret_access_key: String,
+
+        /// Optional session token for temporary credentials.
+        session_token: Option<String>,
+    },
+    /// Use AWS STS to assume a specific IAM role.
+    ///
+    /// Useful for:
+    /// - Cross-account access patterns
+    /// - Temporary elevated permissions
+    /// - Service-to-service authentication
+    /// - Multi-tenant applications with role-based access
+    ///
+    /// **Requirements**:
+    /// - The role must trust the principal making the assume role call
+    /// - Appropriate permissions must be configured on the role
+    /// - MFA may be required depending on role trust policy
+    AssumeRole {
+        /// ARN of the IAM role to assume.
+        ///
+        /// Format: `arn:aws:iam::ACCOUNT-ID:role/ROLE-NAME`
+        /// Example: `arn:aws:iam::123456789012:role/PrismDataAccess`
+        role_arn: String,
+
+        /// Session name for the assumed role session.
+        ///
+        /// This appears in `CloudTrail` logs and can be used for:
+        /// - Auditing and tracking access
+        /// - Identifying specific application instances
+        /// - Debugging authentication issues
+        ///
+        /// Must be 2-64 characters, alphanumeric and +=,.@-_
+        session_name: String,
+
+        /// Optional external ID for additional security.
+        ///
+        /// Used to prevent the "confused deputy" problem in cross-account scenarios.
+        /// Should be a unique, hard-to-guess value shared between accounts.
+        external_id: Option<String>,
+
+        /// Duration of the assumed role session (in seconds).
+        ///
+        /// AWS limits:
+        /// - Minimum: 900 seconds (15 minutes)
+        /// - Maximum: Depends on role's maximum session duration setting
+        /// - Default: 3600 seconds (1 hour)
+        ///
+        /// Consider your application's runtime and security requirements.
+        #[serde_as(as = "DurationSeconds<u64>")]
+        session_duration: Duration,
+    },
+}
+
+impl Default for AwsCredentialsConfig {
+    fn default() -> Self {
+        Self::Default { profile: None }
+    }
+}
+
+impl AwsCredentialsConfig {
+    /// Create credentials config for development with explicit keys.
+    ///
+    /// **WARNING**: Only use for local development. Never commit credentials to version control.
+    pub const fn development(access_key_id: String, secret_access_key: String) -> Self {
+        Self::Explicit {
+            access_key_id,
+            secret_access_key,
+            session_token: None,
+        }
+    }
+
+    /// Create credentials config for cross-account access.
+    pub const fn cross_account(role_arn: String, session_name: String) -> Self {
+        Self::AssumeRole {
+            role_arn,
+            session_name,
+            external_id: None,
+            session_duration: Duration::from_secs(3600), // 1 hour default
+        }
+    }
+
+    /// Create credentials config with specific AWS profile.
+    pub const fn profile(profile_name: String) -> Self {
+        Self::Default {
+            profile: Some(profile_name),
+        }
+    }
+}
+
+#[cfg_attr(coverage_nightly, coverage(off))]
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::aws::{AwsCredentialsConfig, AwsLightClientDAConfig};
+
+    #[cfg(not(target_arch = "wasm32"))]
+    use crate::aws::AwsFullNodeDAConfig;
+
+    fn create_test_light_client_config() -> AwsLightClientDAConfig {
+        AwsLightClientDAConfig {
+            region: "us-east-1".to_string(),
+            endpoint: None,
+            epochs_bucket: "test-epochs-bucket".to_string(),
+            metadata_bucket: "test-metadata-bucket".to_string(),
+            max_timeout: std::time::Duration::from_secs(30),
+            max_retries: 1,
+            credentials: AwsCredentialsConfig::development(
+                "test_access_key".to_string(),
+                "test_secret_key".to_string(),
+            ),
+            key_prefix: String::new(),
+            block_time: Duration::from_secs(1), // Shorter for tests
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn create_test_full_node_config() -> AwsFullNodeDAConfig {
+        AwsFullNodeDAConfig {
+            light_client: AwsLightClientDAConfig {
+                region: "us-east-1".to_string(),
+                endpoint: None,
+                epochs_bucket: "test-epochs-bucket".to_string(),
+                max_timeout: std::time::Duration::from_secs(30),
+                max_retries: 1,
+                credentials: AwsCredentialsConfig::development(
+                    "test_access_key".to_string(),
+                    "test_secret_key".to_string(),
+                ),
+                key_prefix: String::new(),
+                metadata_bucket: "test-metadata-bucket".to_string(),
+                block_time: Duration::from_secs(1), // Shorter for tests
+            },
+            transactions_bucket: "test-transactions-bucket".to_string(),
+            retention_days: 30,
+            enable_legal_holds: false,
+            enable_cross_region_replication: false,
+            replication_region: None,
+            max_concurrent_uploads: 5,
+        }
+    }
+
+    #[test]
+    fn test_light_client_config_structure() {
+        let config = create_test_light_client_config();
+
+        assert_eq!(config.region, "us-east-1");
+        assert_eq!(config.epochs_bucket, "test-epochs-bucket");
+        assert_eq!(config.metadata_bucket, "test-metadata-bucket");
+        assert_eq!(config.max_timeout, Duration::from_secs(30));
+        assert_eq!(config.max_retries, 1);
+        assert_eq!(config.block_time, Duration::from_secs(1));
+        assert!(config.key_prefix.is_empty());
+        assert!(config.endpoint.is_none());
+    }
+
+    #[test]
+    fn test_light_client_config_with_custom_endpoint() {
+        let mut config = create_test_light_client_config();
+        config.endpoint = Some("http://localhost:9000".to_string());
+
+        assert_eq!(config.endpoint, Some("http://localhost:9000".to_string()));
+    }
+
+    #[test]
+    fn test_light_client_config_with_key_prefix() {
+        let mut config = create_test_light_client_config();
+        config.key_prefix = "test/prefix/".to_string();
+
+        assert_eq!(config.key_prefix, "test/prefix/");
+    }
+
+    #[test]
+    fn test_light_client_config_with_different_credentials() {
+        let mut config = create_test_light_client_config();
+
+        // Test explicit credentials
+        config.credentials = AwsCredentialsConfig::development(
+            "different_key".to_string(),
+            "different_secret".to_string(),
+        );
+
+        match config.credentials {
+            AwsCredentialsConfig::Explicit {
+                access_key_id,
+                secret_access_key,
+                ..
+            } => {
+                assert_eq!(access_key_id, "different_key");
+                assert_eq!(secret_access_key, "different_secret");
+            }
+            _ => panic!("Expected explicit credentials"),
+        }
+    }
+
+    #[test]
+    fn test_light_client_config_timeout_and_retries() {
+        let mut config = create_test_light_client_config();
+
+        // Test different timeout values
+        config.max_timeout = Duration::from_secs(60);
+        assert_eq!(config.max_timeout, Duration::from_secs(60));
+
+        config.max_timeout = Duration::from_millis(5000);
+        assert_eq!(config.max_timeout, Duration::from_millis(5000));
+
+        // Test different retry values
+        config.max_retries = 5;
+        assert_eq!(config.max_retries, 5);
+
+        config.max_retries = 0;
+        assert_eq!(config.max_retries, 0);
+    }
+
+    #[test]
+    fn test_light_client_block_time_configuration() {
+        let mut config = create_test_light_client_config();
+
+        // Test different block time values
+        config.block_time = Duration::from_millis(100);
+        assert_eq!(config.block_time, Duration::from_millis(100));
+
+        config.block_time = Duration::from_secs(30);
+        assert_eq!(config.block_time, Duration::from_secs(30));
+
+        config.block_time = Duration::from_millis(500);
+        assert_eq!(config.block_time, Duration::from_millis(500));
+    }
+
+    #[test]
+    fn test_light_client_bucket_configuration() {
+        let mut config = create_test_light_client_config();
+
+        // Test different bucket names
+        config.epochs_bucket = "production-epochs".to_string();
+        config.metadata_bucket = "production-metadata".to_string();
+
+        assert_eq!(config.epochs_bucket, "production-epochs");
+        assert_eq!(config.metadata_bucket, "production-metadata");
+
+        // Test with environment-specific bucket names
+        config.epochs_bucket = "dev-prism-epochs-us-east-1".to_string();
+        config.metadata_bucket = "dev-prism-metadata-us-east-1".to_string();
+
+        assert_eq!(config.epochs_bucket, "dev-prism-epochs-us-east-1");
+        assert_eq!(config.metadata_bucket, "dev-prism-metadata-us-east-1");
+    }
+
+    #[test]
+    fn test_light_client_region_configuration() {
+        let mut config = create_test_light_client_config();
+
+        // Test different AWS regions
+        let regions = vec![
+            "us-west-1",
+            "us-west-2",
+            "eu-west-1",
+            "eu-central-1",
+            "ap-southeast-1",
+        ];
+
+        for region in regions {
+            config.region = region.to_string();
+            assert_eq!(config.region, region);
+        }
+    }
+
+    #[test]
+    fn test_credentials_variants() {
+        let config = create_test_light_client_config();
+
+        // Test that development credentials are properly constructed
+        match config.credentials {
+            AwsCredentialsConfig::Explicit {
+                access_key_id,
+                secret_access_key,
+                session_token,
+            } => {
+                assert_eq!(access_key_id, "test_access_key");
+                assert_eq!(secret_access_key, "test_secret_key");
+                assert!(session_token.is_none());
+            }
+            _ => panic!("Expected explicit credentials for development config"),
+        }
+
+        // Test default credentials
+        let default_creds = AwsCredentialsConfig::default();
+        match default_creds {
+            AwsCredentialsConfig::Default { profile } => {
+                assert!(profile.is_none());
+            }
+            _ => panic!("Expected default credentials"),
+        }
+
+        // Test profile-based credentials
+        let profile_creds = AwsCredentialsConfig::profile("test-profile".to_string());
+        match profile_creds {
+            AwsCredentialsConfig::Default { profile } => {
+                assert_eq!(profile, Some("test-profile".to_string()));
+            }
+            _ => panic!("Expected profile-based credentials"),
+        }
+    }
+
+    // Full node config tests
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_full_node_config_structure() {
+        let config = create_test_full_node_config();
+
+        assert_eq!(config.retention_days, 30);
+        assert!(!config.enable_legal_holds);
+        assert!(!config.enable_cross_region_replication);
+        assert_eq!(config.max_concurrent_uploads, 5);
+        assert_eq!(config.light_client.epochs_bucket, "test-epochs-bucket");
+        assert_eq!(config.transactions_bucket, "test-transactions-bucket");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_full_node_config_with_replication() {
+        let mut config = create_test_full_node_config();
+        config.enable_cross_region_replication = true;
+        config.replication_region = Some("us-west-2".to_string());
+
+        assert!(config.enable_cross_region_replication);
+        assert_eq!(config.replication_region, Some("us-west-2".to_string()));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_full_node_config_with_legal_holds() {
+        let mut config = create_test_full_node_config();
+        config.enable_legal_holds = true;
+
+        assert!(config.enable_legal_holds);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_full_node_worm_features_config() {
+        let config = create_test_full_node_config();
+
+        // Test WORM-related configuration
+        assert_eq!(config.retention_days, 30);
+        assert!(!config.enable_legal_holds);
+
+        // Test with different retention periods
+        let mut long_retention_config = config.clone();
+        long_retention_config.retention_days = 365;
+        assert_eq!(long_retention_config.retention_days, 365);
+
+        // Test with legal holds enabled
+        let mut legal_hold_config = config;
+        legal_hold_config.enable_legal_holds = true;
+        assert!(legal_hold_config.enable_legal_holds);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_full_node_concurrent_upload_config() {
+        let mut config = create_test_full_node_config();
+
+        // Test default concurrent uploads
+        assert_eq!(config.max_concurrent_uploads, 5);
+
+        // Test different values
+        config.max_concurrent_uploads = 10;
+        assert_eq!(config.max_concurrent_uploads, 10);
+
+        config.max_concurrent_uploads = 1;
+        assert_eq!(config.max_concurrent_uploads, 1);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_full_node_block_time_configuration() {
+        let mut config = create_test_full_node_config();
+
+        // Test default block time (set to 1 second for tests)
+        assert_eq!(config.light_client.block_time, Duration::from_secs(1));
+
+        // Test different block times
+        config.light_client.block_time = Duration::from_millis(500);
+        assert_eq!(config.light_client.block_time, Duration::from_millis(500));
+
+        config.light_client.block_time = Duration::from_secs(12);
+        assert_eq!(config.light_client.block_time, Duration::from_secs(12));
+    }
+}

--- a/crates/da/src/aws/full_node.rs
+++ b/crates/da/src/aws/full_node.rs
@@ -1,0 +1,206 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use prism_common::transaction::Transaction;
+use prism_errors::DataAvailabilityError;
+use prism_events::{EventChannel, PrismEvent};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+use tokio::{
+    sync::{RwLock, broadcast},
+    task::JoinHandle,
+    time::Duration,
+};
+use tracing::{debug, info, warn};
+
+use crate::{
+    DataAvailabilityLayer, FinalizedEpoch, LightDataAvailabilityLayer, VerifiableEpoch,
+    aws::client::{AwsDaMetaInfo, AwsDataAvailabilityClient},
+};
+
+use super::config::AwsFullNodeDAConfig;
+
+/// AWS S3-based full node data availability layer.
+///
+/// This implementation provides full read-write access to both finalized epochs and
+/// transaction data using AWS S3 with WORM (Write Once Read Many) compliance through
+/// S3 Object Lock features.
+///
+/// # Features
+///
+/// - **WORM Compliance**: Automatic Object Lock with configurable retention periods
+/// - **Legal Holds**: Additional protection for critical data beyond retention periods
+/// - **Cross-Region Replication**: Automatic data replication for disaster recovery
+/// - **Concurrent Uploads**: Parallel transaction publishing with rate limiting
+/// - **Height Broadcasting**: Real-time height updates to network participants
+/// - **Automatic Retry**: Exponential backoff for transient failures
+///
+/// # WORM Workflow
+///
+/// For each published object, the system:
+/// 1. **Upload**: Write data to S3 with temporary accessibility
+/// 2. **Lock**: Apply Object Lock with compliance mode and retention period
+/// 3. **Hold**: Optionally apply legal hold for additional protection
+/// 4. **Verify**: Confirm successful upload and lock application
+/// 5. **Broadcast**: Notify network of data availability
+pub struct AwsFullNodeDataAvailabilityLayer {
+    /// AWS S3 client for data operations
+    client: Arc<AwsDataAvailabilityClient>,
+
+    /// Current height with built-in synchronization for race condition protection
+    current_height: Arc<RwLock<u64>>,
+
+    /// Transaction offset for the current height
+    transaction_offset: Arc<AtomicU64>,
+
+    /// Block time for the network
+    block_time: Duration,
+
+    /// Height update broadcaster
+    height_update_tx: broadcast::Sender<u64>,
+
+    /// Event channel for publishing data availability events
+    event_channel: Arc<EventChannel>,
+
+    /// Background task handle for height monitoring
+    _height_monitor_handle: Option<JoinHandle<()>>,
+}
+
+impl AwsFullNodeDataAvailabilityLayer {
+    pub async fn new(config: &AwsFullNodeDAConfig) -> Result<Self, DataAvailabilityError> {
+        let client = AwsDataAvailabilityClient::new_from_full_da_config(config.clone()).await?;
+
+        let (height_update_tx, _) = broadcast::channel(100);
+        let event_channel = Arc::new(EventChannel::new());
+
+        debug!(
+            "AWS full node initialized for region '{}', epochs bucket '{}', retention {} days",
+            config.light_client.region, config.light_client.epochs_bucket, config.retention_days
+        );
+
+        Ok(Self {
+            client: Arc::new(client),
+            current_height: Arc::new(RwLock::new(1)),
+            transaction_offset: Arc::new(AtomicU64::new(0)),
+            block_time: config.light_client.block_time,
+            height_update_tx,
+            event_channel,
+            _height_monitor_handle: None,
+        })
+    }
+
+    async fn produce_blocks(&self) -> Result<(), DataAvailabilityError> {
+        let client = self.client.clone();
+        let current_height = self.current_height.clone();
+        let height_update_tx = self.height_update_tx.clone();
+        let event_publisher = self.event_channel.publisher();
+        let block_time = self.block_time;
+
+        let _handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(block_time).await;
+
+                // Take write lock to atomically increment height and prevent submissions
+                let mut height_guard = current_height.write().await;
+                let completed_height = *height_guard;
+                *height_guard += 1;
+                drop(height_guard);
+
+                // Broadcast height update
+                let _ = height_update_tx.send(completed_height);
+
+                // Publish event
+                event_publisher.send(PrismEvent::UpdateDAHeight {
+                    height: completed_height,
+                });
+
+                // Update metadata
+                let metadata = AwsDaMetaInfo {
+                    current_height: completed_height,
+                };
+
+                if let Err(e) = client.submit_metadata(metadata).await {
+                    warn!("Failed to submit metadata: {}", e);
+                }
+
+                info!("Completed block {}", completed_height);
+            }
+        });
+
+        debug!("Started height monitoring task with race condition protection");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl LightDataAvailabilityLayer for AwsFullNodeDataAvailabilityLayer {
+    async fn start(&self) -> Result<()> {
+        info!("Starting AWS full node data availability layer");
+
+        let current_height = *self.current_height.read().await;
+        info!(
+            "AWS full node data availability layer started at height {}",
+            current_height
+        );
+
+        self.produce_blocks().await?;
+
+        Ok(())
+    }
+
+    async fn get_finalized_epochs(&self, height: u64) -> Result<Vec<VerifiableEpoch>> {
+        self.client
+            .fetch_epochs(height)
+            .await
+            .map(|epochs| epochs.into_iter().map(|e| Box::new(e) as VerifiableEpoch).collect())
+            .map_err(|e| anyhow!(e.to_string()))
+    }
+
+    fn event_channel(&self) -> Arc<EventChannel> {
+        self.event_channel.clone()
+    }
+}
+
+#[async_trait]
+impl DataAvailabilityLayer for AwsFullNodeDataAvailabilityLayer {
+    async fn get_latest_height(&self) -> Result<u64> {
+        Ok(*self.current_height.read().await)
+    }
+
+    async fn get_transactions(&self, height: u64) -> anyhow::Result<Vec<Transaction>> {
+        self.client.fetch_transactions(height).await.map_err(|e| anyhow!(e.to_string()))
+    }
+
+    async fn submit_finalized_epoch(&self, epoch: FinalizedEpoch) -> Result<u64> {
+        // Take read lock to get consistent height and prevent increments during submission
+        let height_guard = self.current_height.read().await;
+        let current_height = *height_guard;
+
+        self.client.submit_finalized_epoch(epoch, current_height).await?;
+
+        info!("Finalized epoch submitted at height {}", current_height);
+
+        // Return the height where the epoch was published
+        Ok(current_height)
+    }
+
+    async fn submit_transactions(&self, transactions: Vec<Transaction>) -> Result<u64> {
+        // Take read lock to get consistent height and prevent increments during submission
+        let height_guard = self.current_height.read().await;
+        let height = *height_guard;
+        let transaction_offset = self.transaction_offset.load(Ordering::Relaxed);
+
+        self.client.submit_transactions(transactions, transaction_offset, height).await?;
+
+        info!("Transactions submitted at height {}", height);
+
+        Ok(height)
+    }
+
+    fn subscribe_to_heights(&self) -> broadcast::Receiver<u64> {
+        self.height_update_tx.subscribe()
+    }
+}

--- a/crates/da/src/aws/full_node.rs
+++ b/crates/da/src/aws/full_node.rs
@@ -218,6 +218,7 @@ impl DataAvailabilityLayer for AwsFullNodeDataAvailabilityLayer {
         // Take read lock to get consistent height and prevent increments during submission
         let height_guard = self.current_height.read().await;
         let height = *height_guard;
+        drop(height_guard);
         let transaction_offset = self.transaction_offset.load(Ordering::Relaxed);
 
         let count = transactions.len() as u64;

--- a/crates/da/src/aws/full_node.rs
+++ b/crates/da/src/aws/full_node.rs
@@ -11,7 +11,6 @@ use std::sync::{
 };
 use tokio::{
     sync::{RwLock, broadcast},
-    task::JoinHandle,
     time::Duration,
 };
 use tokio_util::sync::CancellationToken;

--- a/crates/da/src/aws/light_client.rs
+++ b/crates/da/src/aws/light_client.rs
@@ -1,0 +1,106 @@
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use prism_errors::DataAvailabilityError;
+use prism_events::{EventChannel, EventPublisher, PrismEvent};
+use std::{sync::Arc, time::Duration};
+use tracing::{debug, info, warn};
+
+use crate::{LightDataAvailabilityLayer, VerifiableEpoch, aws::client::AwsDataAvailabilityClient};
+
+use super::config::AwsLightClientDAConfig;
+
+/// AWS S3-based light data availability layer.
+///
+/// This implementation provides read-only access to finalized epochs stored in AWS S3
+/// with WORM (Write Once Read Many) compliance. Light clients can efficiently verify
+/// data availability through this layer.
+#[derive(Clone)]
+pub struct AwsLightDataAvailabilityLayer {
+    /// AWS S3 client for data operations
+    client: AwsDataAvailabilityClient,
+
+    /// Event channel for publishing data availability events
+    event_channel: Arc<EventChannel>,
+
+    block_time: Duration,
+}
+
+impl AwsLightDataAvailabilityLayer {
+    /// Creates a new AWS light data availability layer.
+    pub async fn new(config: &AwsLightClientDAConfig) -> Result<Self, DataAvailabilityError> {
+        let client = AwsDataAvailabilityClient::new_from_light_da_config(config.clone()).await?;
+
+        Ok(Self {
+            client,
+            event_channel: Arc::new(EventChannel::new()),
+            block_time: config.block_time,
+        })
+    }
+
+    /// Creates an event publisher for this layer.
+    pub fn event_publisher(&self) -> EventPublisher {
+        self.event_channel.publisher()
+    }
+
+    /// Starts the height monitoring background task.
+    ///
+    /// Since S3 doesn't have built-in height notifications like blockchain nodes,
+    /// we simulate height updates by periodically checking for new data and
+    /// broadcasting updates when found.
+    async fn start_height_monitoring(&self) -> Result<(), DataAvailabilityError> {
+        let client = Arc::new(self.client.clone());
+        let event_publisher = self.event_channel.publisher();
+        let poll_interval = self.block_time;
+
+        let _handle = tokio::spawn(async move {
+            let mut last_height = 0u64;
+
+            loop {
+                match client.fetch_height().await {
+                    Ok(Some(max_height)) => {
+                        if max_height > last_height {
+                            last_height = max_height;
+
+                            // Publish event
+                            event_publisher.send(PrismEvent::UpdateDAHeight { height: max_height });
+
+                            info!("Height updated to {}", max_height);
+                        }
+                    }
+                    Ok(None) => {
+                        debug!("No height metadata available yet");
+                    }
+                    Err(e) => {
+                        warn!("Failed to check for height updates: {}", e);
+                    }
+                }
+
+                tokio::time::sleep(poll_interval).await;
+            }
+        });
+
+        debug!("Started height monitoring task");
+        Ok(())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl LightDataAvailabilityLayer for AwsLightDataAvailabilityLayer {
+    async fn start(&self) -> Result<()> {
+        self.start_height_monitoring().await?;
+        Ok(())
+    }
+
+    fn event_channel(&self) -> Arc<EventChannel> {
+        self.event_channel.clone()
+    }
+
+    async fn get_finalized_epochs(&self, height: u64) -> Result<Vec<VerifiableEpoch>> {
+        self.client
+            .fetch_epochs(height)
+            .await
+            .map(|epochs| epochs.into_iter().map(|e| Box::new(e) as VerifiableEpoch).collect())
+            .map_err(|e| anyhow!(e.to_string()))
+    }
+}

--- a/crates/da/src/aws/mod.rs
+++ b/crates/da/src/aws/mod.rs
@@ -1,0 +1,157 @@
+//! AWS S3-based data availability layer implementation.
+//!
+//! This module provides data availability layer implementations using AWS S3
+//! with WORM (Write Once Read Many) compliance through S3 Object Lock features.
+//!
+//! # Features
+//!
+//! - **WORM Compliance**: Automatic Object Lock with configurable retention periods
+//! - **Light Client Support**: Efficient read-only access to finalized epochs
+//! - **Full Node Support**: Complete read-write access to epochs and transactions
+//! - **Cross-Region Replication**: Disaster recovery through automatic replication
+//! - **Legal Holds**: Additional data protection beyond retention periods
+//! - **Concurrent Operations**: Parallel uploads with configurable rate limiting
+//!
+//! # WORM Model Implementation
+//!
+//! The AWS implementation leverages S3 Object Lock to provide WORM capabilities:
+//!
+//! ## Object Lock Features
+//! - **Compliance Mode**: Prevents object deletion/modification, even by root users
+//! - **Retention Periods**: Configurable time-based protection (days to years)
+//! - **Legal Holds**: Additional protection for litigation/compliance needs
+//! - **Versioning**: Maintains complete audit trails of object changes
+//!
+//! ## Data Organization
+//! ```text
+//! bucket/
+//! ├── epochs/
+//! │   ├── 1/epoch.bin          (height 1 epoch data)
+//! │   ├── 2/epoch.bin          (height 2 epoch data)
+//! │   └── ...
+//! ├── transactions/
+//! │   ├── 1/
+//! │   │   ├── tx_0.bin         (transaction 0 at height 1)
+//! │   │   ├── tx_1.bin         (transaction 1 at height 1)
+//! │   │   └── ...
+//! │   └── 2/
+//! │       ├── tx_0.bin         (transaction 0 at height 2)
+//! │       └── ...
+//! └── metadata/
+//!     ├── epochs/1/info.json   (metadata for epoch 1)
+//!     └── transactions/1/info.json
+//! ```
+//!
+//! # Security Considerations
+//!
+//! ## IAM Permissions
+//! The AWS credentials must have appropriate permissions:
+//!
+//! ### Light Client (Minimum)
+//! ```json
+//! {
+//!   "Version": "2012-10-17",
+//!   "Statement": [
+//!     {
+//!       "Effect": "Allow",
+//!       "Action": [
+//!         "s3:GetObject",
+//!         "s3:ListBucket",
+//!         "s3:GetObjectVersion"
+//!       ],
+//!       "Resource": [
+//!         "arn:aws:s3:::your-epochs-bucket",
+//!         "arn:aws:s3:::your-epochs-bucket/*"
+//!       ]
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! ### Full Node (Complete)
+//! ```json
+//! {
+//!   "Version": "2012-10-17",
+//!   "Statement": [
+//!     {
+//!       "Effect": "Allow",
+//!       "Action": [
+//!         "s3:GetObject",
+//!         "s3:PutObject",
+//!         "s3:ListBucket",
+//!         "s3:GetObjectVersion",
+//!         "s3:PutObjectRetention",
+//!         "s3:PutObjectLegalHold",
+//!         "s3:GetObjectLockConfiguration"
+//!       ],
+//!       "Resource": [
+//!         "arn:aws:s3:::your-epochs-bucket",
+//!         "arn:aws:s3:::your-epochs-bucket/*",
+//!         "arn:aws:s3:::your-transactions-bucket",
+//!         "arn:aws:s3:::your-transactions-bucket/*"
+//!       ]
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! # Usage Examples
+//!
+//! ## Light Client
+//!
+//! ```rust,no_run
+//! use prism_da::aws::{AwsLightDataAvailabilityLayer, AwsLightClientDAConfig};
+//! use prism_da::LightDataAvailabilityLayer;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let config = AwsLightClientDAConfig::default();
+//!     let da = AwsLightDataAvailabilityLayer::new(&config).await?;
+//!
+//!     let epochs = da.get_finalized_epochs(100).await?;
+//!     println!("Found {} epochs at height 100", epochs.len());
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Full Node
+//!
+//! ```rust,no_run
+//! use prism_da::aws::{AwsFullNodeDataAvailabilityLayer, AwsFullNodeDAConfig};
+//! use prism_da::{DataAvailabilityLayer, LightDataAvailabilityLayer};
+//! use prism_common::transaction::Transaction;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let config = AwsFullNodeDAConfig::default();
+//!     let da = AwsFullNodeDataAvailabilityLayer::new(&config).await?;
+//!
+//!     da.start().await?;
+//!
+//!     let transactions = vec![/* your transactions */];
+//!     let height = da.submit_transactions(transactions).await?;
+//!     println!("Published at height: {}", height);
+//!
+//!     Ok(())
+//! }
+//! ```
+
+pub mod client;
+pub mod config;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod full_node;
+pub mod light_client;
+
+pub use config::{
+    AwsCredentialsConfig, AwsLightClientDAConfig, DEFAULT_AWS_REGION, DEFAULT_RETENTION_DAYS,
+    DEFAULT_S3_MAX_RETRIES, DEFAULT_S3_MAX_TIMEOUT,
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use config::AwsFullNodeDAConfig;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use full_node::AwsFullNodeDataAvailabilityLayer;
+
+pub use light_client::AwsLightDataAvailabilityLayer;

--- a/crates/da/src/aws/mod.rs
+++ b/crates/da/src/aws/mod.rs
@@ -26,20 +26,19 @@
 //! ```text
 //! bucket/
 //! ├── epochs/
-//! │   ├── 1/epoch.bin          (height 1 epoch data)
-//! │   ├── 2/epoch.bin          (height 2 epoch data)
+//! │   ├── 000000000001/epoch_0.bin    (epoch 0 at height 1)
+//! │   ├── 000000000002/epoch_1.bin    (epoch 1 at height 1)
 //! │   └── ...
 //! ├── transactions/
-//! │   ├── 1/
+//! │   ├── 000000000001/
 //! │   │   ├── tx_0.bin         (transaction 0 at height 1)
 //! │   │   ├── tx_1.bin         (transaction 1 at height 1)
 //! │   │   └── ...
-//! │   └── 2/
+//! │   └── 000000000002/
 //! │       ├── tx_0.bin         (transaction 0 at height 2)
 //! │       └── ...
 //! └── metadata/
-//!     ├── epochs/1/info.json   (metadata for epoch 1)
-//!     └── transactions/1/info.json
+//!     ├── info.json            (metadata for both things)
 //! ```
 //!
 //! # Security Considerations
@@ -98,7 +97,6 @@
 //! # Usage Examples
 //!
 //! ## Light Client
-//!
 //! ```rust,no_run
 //! use prism_da::aws::{AwsLightDataAvailabilityLayer, AwsLightClientDAConfig};
 //! use prism_da::LightDataAvailabilityLayer;
@@ -116,7 +114,6 @@
 //! ```
 //!
 //! ## Full Node
-//!
 //! ```rust,no_run
 //! use prism_da::aws::{AwsFullNodeDataAvailabilityLayer, AwsFullNodeDAConfig};
 //! use prism_da::{DataAvailabilityLayer, LightDataAvailabilityLayer};

--- a/crates/da/src/celestia/light_client.rs
+++ b/crates/da/src/celestia/light_client.rs
@@ -250,11 +250,12 @@ impl CelestiaLightClientDAConfig {
 }
 
 pub struct LightClientConnection {
-    node: Arc<RwLock<LuminaNode>>,
+    node: Arc<RwLock<Option<LuminaNode>>>,
     event_channel: Arc<EventChannel>,
     snark_namespace: Namespace,
     fetch_timeout: Duration,
     fetch_max_retries: u64,
+    config: CelestiaLightClientDAConfig,
 }
 
 impl LightClientConnection {
@@ -354,23 +355,51 @@ impl LightClientConnection {
     }
 
     pub async fn new(config: &CelestiaLightClientDAConfig) -> Result<Self, DataAvailabilityError> {
-        let (blockstore, store) = Self::setup_stores(&config.store).await?;
+        Ok(Self {
+            node: Arc::new(RwLock::new(None)),
+            event_channel: Arc::new(EventChannel::new()),
+            snark_namespace: create_namespace(&config.snark_namespace_id)?,
+            fetch_timeout: config.fetch_timeout,
+            fetch_max_retries: config.fetch_max_retries,
+            config: config.clone(),
+        })
+    }
+
+    pub fn event_publisher(&self) -> EventPublisher {
+        self.event_channel.publisher()
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl LightDataAvailabilityLayer for LightClientConnection {
+    async fn start(&self) -> Result<()> {
+        // Check if already started
+        {
+            let node_guard = self.node.read().await;
+            if node_guard.is_some() {
+                return Ok(()); // Already started
+            }
+        }
+
+        let (blockstore, store) = Self::setup_stores(&self.config.store).await?;
 
         let mut node = NodeBuilder::new()
-            .network(config.celestia_network.clone())
+            .network(self.config.celestia_network.clone())
             .store(store)
             .blockstore(blockstore)
-            .pruning_window(config.pruning_window);
+            .pruning_window(self.config.pruning_window);
 
-        if !config.bootnodes.is_empty() {
-            let multiaddrs: Vec<Multiaddr> = config
+        if !self.config.bootnodes.is_empty() {
+            let multiaddrs: Vec<Multiaddr> = self
+                .config
                 .bootnodes
                 .clone()
                 .into_iter()
                 .filter_map(|addr| Multiaddr::from_str(&addr).ok())
                 .collect();
 
-            if multiaddrs.len() != config.bootnodes.len() {
+            if multiaddrs.len() != self.config.bootnodes.len() {
                 warn!(
                     "Some bootnodes failed to parse to libp2p multiaddrs. Valid addresses contain: {:#?}",
                     multiaddrs
@@ -387,28 +416,16 @@ impl LightClientConnection {
 
         let lumina_sub = Arc::new(Mutex::new(event_subscriber));
 
-        // Creates an EventChannel that starts forwarding lumina events to the subscriber
-        let prism_chan = EventChannel::from(lumina_sub);
+        // Start forwarding lumina events to our existing event channel
+        self.event_channel.start_forwarding(lumina_sub);
 
-        Ok(Self {
-            node: Arc::new(RwLock::new(node)),
-            event_channel: Arc::new(prism_chan),
-            snark_namespace: create_namespace(&config.snark_namespace_id)?,
-            fetch_timeout: config.fetch_timeout,
-            fetch_max_retries: config.fetch_max_retries,
-        })
-    }
+        // Store the node
+        {
+            let mut node_guard = self.node.write().await;
+            *node_guard = Some(node);
+        }
 
-    pub fn event_publisher(&self) -> EventPublisher {
-        self.event_channel.publisher()
-    }
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-impl LightDataAvailabilityLayer for LightClientConnection {
-    fn event_channel(&self) -> Arc<EventChannel> {
-        self.event_channel.clone()
+        Ok(())
     }
 
     async fn get_finalized_epochs(&self, height: u64) -> Result<Vec<VerifiableEpoch>> {
@@ -416,7 +433,11 @@ impl LightDataAvailabilityLayer for LightClientConnection {
             "searching for epoch on da layer at height {} under namespace",
             height
         );
-        let node = self.node.read().await;
+        let node_guard = self.node.read().await;
+        let node = match node_guard.as_ref() {
+            Some(n) => n,
+            None => return Err(anyhow!("Light client not started. Call start() first.")),
+        };
 
         for attempt in 0..self.fetch_max_retries {
             match node
@@ -451,5 +472,9 @@ impl LightDataAvailabilityLayer for LightClientConnection {
             height,
             "Max retry count exceeded".to_string()
         )));
+    }
+
+    fn event_channel(&self) -> Arc<EventChannel> {
+        self.event_channel.clone()
     }
 }

--- a/crates/da/src/factory.rs
+++ b/crates/da/src/factory.rs
@@ -23,7 +23,7 @@ use crate::{
     memory::InMemoryDataAvailabilityLayer,
 };
 
-#[cfg(feature = "aws")]
+#[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
 use crate::aws::{AwsLightClientDAConfig, AwsLightDataAvailabilityLayer};
 
 /// Configuration for the Data Availability layer used by light clients.
@@ -41,7 +41,7 @@ pub enum LightClientDAConfig {
     /// AWS S3 DA configuration with light client support.
     /// Provides WORM-compliant data retrieval from S3 Object Lock buckets
     /// with configurable regions and credentials.
-    #[cfg(feature = "aws")]
+    #[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
     Aws(AwsLightClientDAConfig),
 
     /// In-memory DA layer for testing and development.
@@ -115,9 +115,8 @@ pub async fn create_light_client_da_layer(
             let connection = LightClientConnection::new(celestia_config).await?;
             Ok(Arc::new(connection))
         }
-        #[cfg(feature = "aws")]
+        #[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
         LightClientDAConfig::Aws(aws_config) => {
-            info!("Using AWS config: {:?}", aws_config);
             let connection = AwsLightDataAvailabilityLayer::new(aws_config).await?;
             Ok(Arc::new(connection))
         }
@@ -235,9 +234,8 @@ pub async fn create_full_node_da_layer(
             }
             unreachable!() // This line should never be reached due to the return in the last iteration
         }
-        #[cfg(feature = "aws")]
+        #[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
         FullNodeDAConfig::Aws(aws_config) => {
-            info!("Using AWS config: {:?}", aws_config);
             for attempt in 1..=DA_RETRY_COUNT {
                 match AwsFullNodeDataAvailabilityLayer::new(aws_config).await {
                     Ok(da) => return Ok(Arc::new(da)),

--- a/crates/da/src/factory.rs
+++ b/crates/da/src/factory.rs
@@ -14,11 +14,17 @@ use crate::{
     celestia::{CelestiaConnection, CelestiaFullNodeDAConfig, CelestiaLightClientDAStoreConfig},
     consts::{DA_RETRY_COUNT, DA_RETRY_INTERVAL},
 };
+
+#[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
+use crate::aws::{AwsFullNodeDAConfig, AwsFullNodeDataAvailabilityLayer};
 use crate::{
     LightDataAvailabilityLayer,
     celestia::{CelestiaLightClientDAConfig, LightClientConnection},
     memory::InMemoryDataAvailabilityLayer,
 };
+
+#[cfg(feature = "aws")]
+use crate::aws::{AwsLightClientDAConfig, AwsLightDataAvailabilityLayer};
 
 /// Configuration for the Data Availability layer used by light clients.
 ///
@@ -31,6 +37,12 @@ pub enum LightClientDAConfig {
     /// Provides efficient data retrieval through light client protocols
     /// with configurable pruning and retry policies.
     Celestia(CelestiaLightClientDAConfig),
+
+    /// AWS S3 DA configuration with light client support.
+    /// Provides WORM-compliant data retrieval from S3 Object Lock buckets
+    /// with configurable regions and credentials.
+    #[cfg(feature = "aws")]
+    Aws(AwsLightClientDAConfig),
 
     /// In-memory DA layer for testing and development.
     /// Data is stored locally and not persisted across restarts.
@@ -103,6 +115,12 @@ pub async fn create_light_client_da_layer(
             let connection = LightClientConnection::new(celestia_config).await?;
             Ok(Arc::new(connection))
         }
+        #[cfg(feature = "aws")]
+        LightClientDAConfig::Aws(aws_config) => {
+            info!("Using AWS config: {:?}", aws_config);
+            let connection = AwsLightDataAvailabilityLayer::new(aws_config).await?;
+            Ok(Arc::new(connection))
+        }
         LightClientDAConfig::InMemory => {
             let (da_layer, _height_rx, _block_rx) =
                 InMemoryDataAvailabilityLayer::new(Duration::from_secs(10));
@@ -123,6 +141,12 @@ pub enum FullNodeDAConfig {
     /// Provides complete DA functionality including transaction publishing,
     /// block retrieval, and serving light clients.
     Celestia(CelestiaFullNodeDAConfig),
+
+    /// AWS S3 DA configuration with full node capabilities.
+    /// Provides WORM-compliant data publishing and retrieval using S3 Object Lock
+    /// with configurable retention periods and cross-region replication.
+    #[cfg(feature = "aws")]
+    Aws(AwsFullNodeDAConfig),
 
     /// In-memory DA layer for testing and development.
     /// Simulates DA operations locally without network connectivity.
@@ -201,6 +225,31 @@ pub async fn create_full_node_da_layer(
                         }
                         error!(
                             "Attempt {} to connect to celestia node failed: {}. Retrying in {} seconds...",
+                            attempt,
+                            e,
+                            DA_RETRY_INTERVAL.as_secs()
+                        );
+                        tokio::time::sleep(DA_RETRY_INTERVAL).await;
+                    }
+                }
+            }
+            unreachable!() // This line should never be reached due to the return in the last iteration
+        }
+        #[cfg(feature = "aws")]
+        FullNodeDAConfig::Aws(aws_config) => {
+            info!("Using AWS config: {:?}", aws_config);
+            for attempt in 1..=DA_RETRY_COUNT {
+                match AwsFullNodeDataAvailabilityLayer::new(aws_config).await {
+                    Ok(da) => return Ok(Arc::new(da)),
+                    Err(e) => {
+                        if attempt == DA_RETRY_COUNT {
+                            return Err(DataAvailabilityError::NetworkError(format!(
+                                "failed to connect to AWS S3 after {} attempts: {}",
+                                DA_RETRY_COUNT, e
+                            )));
+                        }
+                        error!(
+                            "Attempt {} to connect to AWS S3 failed: {}. Retrying in {} seconds...",
                             attempt,
                             e,
                             DA_RETRY_INTERVAL.as_secs()
@@ -345,5 +394,117 @@ mod tests {
         assert!(result.is_ok());
         // We can't easily test the exact type due to trait objects, but we can verify it was
         // created
+    }
+
+    #[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn test_create_aws_light_client_da_layer() {
+        use crate::aws::{AwsCredentialsConfig, AwsLightClientDAConfig};
+
+        let config = LightClientDAConfig::Aws(AwsLightClientDAConfig {
+            region: "us-east-1".to_string(),
+            endpoint: Some("http://localhost:4566".to_string()), // LocalStack for testing
+            epochs_bucket: "test-epochs-bucket".to_string(),
+            metadata_bucket: "test-metadata-bucket".to_string(),
+            max_timeout: Duration::from_secs(10),
+            max_retries: 1,
+            credentials: AwsCredentialsConfig::development("test".to_string(), "test".to_string()),
+            key_prefix: String::new(),
+            block_time: Duration::from_millis(100),
+        });
+
+        let result = create_light_client_da_layer(&config).await;
+
+        // This will typically fail in CI without AWS/LocalStack setup, which is expected
+        match result {
+            Ok(_da_layer) => {
+                // Success case - would happen with proper AWS setup
+                println!("AWS light client DA layer created successfully");
+            }
+            Err(e) => {
+                // Expected failure case in test environment
+                assert!(
+                    e.to_string().contains("InitializationError")
+                        || e.to_string().contains("NetworkError")
+                        || e.to_string().contains("Connection")
+                        || e.to_string().contains("credentials")
+                );
+            }
+        }
+    }
+
+    #[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    async fn test_create_aws_full_node_da_layer() {
+        use crate::aws::{AwsCredentialsConfig, AwsFullNodeDAConfig, AwsLightClientDAConfig};
+
+        let config = FullNodeDAConfig::Aws(AwsFullNodeDAConfig {
+            light_client: AwsLightClientDAConfig {
+                region: "us-east-1".to_string(),
+                endpoint: Some("http://localhost:4566".to_string()), // LocalStack for testing
+                epochs_bucket: "test-epochs-bucket".to_string(),
+                metadata_bucket: "test-metadata-bucket".to_string(),
+                max_timeout: Duration::from_secs(10),
+                max_retries: 1,
+                credentials: AwsCredentialsConfig::development(
+                    "test".to_string(),
+                    "test".to_string(),
+                ),
+                key_prefix: String::new(),
+                block_time: Duration::from_millis(100),
+            },
+            transactions_bucket: "test-transactions-bucket".to_string(),
+            retention_days: 1,
+            enable_legal_holds: false,
+            enable_cross_region_replication: false,
+            replication_region: None,
+            max_concurrent_uploads: 2,
+        });
+
+        let result = create_full_node_da_layer(&config).await;
+
+        // This will typically fail in CI without AWS/LocalStack setup, which is expected
+        match result {
+            Ok(_da_layer) => {
+                // Success case - would happen with proper AWS setup
+                println!("AWS full node DA layer created successfully");
+            }
+            Err(e) => {
+                // Expected failure case in test environment
+                assert!(
+                    e.to_string().contains("failed to connect to AWS S3")
+                        || e.to_string().contains("InitializationError")
+                        || e.to_string().contains("NetworkError")
+                );
+            }
+        }
+    }
+
+    #[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
+    #[test]
+    fn test_aws_preset_compatibility() {
+        use crate::aws::{AwsFullNodeDAConfig, AwsLightClientDAConfig};
+
+        // Test that AWS configs work with presets
+        let mut aws_full_config = FullNodeDAConfig::Aws(AwsFullNodeDAConfig {
+            light_client: AwsLightClientDAConfig::default(),
+            transactions_bucket: "test-bucket".to_string(),
+            retention_days: 30,
+            enable_legal_holds: false,
+            enable_cross_region_replication: false,
+            replication_region: None,
+            max_concurrent_uploads: 5,
+        });
+
+        // Apply development preset - should switch to InMemory
+        let result = aws_full_config.apply_preset(&FullNodePreset::Development);
+        assert!(result.is_ok());
+        assert!(matches!(aws_full_config, FullNodeDAConfig::InMemory));
+
+        // Test with Specter preset - should switch to Celestia
+        let mut aws_config = FullNodeDAConfig::Aws(AwsFullNodeDAConfig::default());
+        let result = aws_config.apply_preset(&FullNodePreset::Specter);
+        assert!(result.is_ok());
+        assert!(matches!(aws_config, FullNodeDAConfig::Celestia(_)));
     }
 }

--- a/crates/da/src/lib.rs
+++ b/crates/da/src/lib.rs
@@ -48,6 +48,7 @@
 //!     // In-memory for development
 //!     let config = LightClientDAConfig::InMemory;
 //!     let da = create_light_client_da_layer(&config).await?;
+//!     da.start().await?;
 //!
 //!     let epochs = da.get_finalized_epochs(100).await?;
 //!     for epoch in epochs {

--- a/crates/da/src/lib.rs
+++ b/crates/da/src/lib.rs
@@ -95,7 +95,7 @@
 //! }
 //! ```
 
-#[cfg(feature = "aws")]
+#[cfg(all(feature = "aws", not(target_arch = "wasm32")))]
 pub mod aws;
 pub mod celestia;
 pub mod consts;

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 serde = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true }
 web-time = { workspace = true, features = ["serde"] }
 prism-common = { workspace = true }

--- a/crates/node_types/lightclient/src/lightclient.rs
+++ b/crates/node_types/lightclient/src/lightclient.rs
@@ -153,6 +153,8 @@ impl LightClient {
 
     #[cfg(target_arch = "wasm32")]
     pub async fn run(self: Arc<Self>) -> Result<()> {
+        self.da.start().await?;
+
         let (_, _) =
             std::future::join!(self.clone().sync_incoming_heights(), self.sync_backwards()).await;
 
@@ -161,6 +163,8 @@ impl LightClient {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn run(self: Arc<Self>) -> Result<()> {
+        self.da.start().await?;
+
         let mut futures = JoinSet::new();
 
         let lc = Arc::clone(&self);

--- a/crates/node_types/uniffi-lightclient/src/lib.rs
+++ b/crates/node_types/uniffi-lightclient/src/lib.rs
@@ -46,16 +46,19 @@ impl LightClient {
             LightClientError::initialization_error(format!("Adjusting path failed: {}", e))
         })?;
 
-        let da = create_light_client_da_layer(&config.da).await.map_err(|e| {
-            LightClientError::initialization_error(format!(
-                "Failed to create light client DA: {}",
-                e
-            ))
-        })?;
+        let cancellation_token = CancellationToken::new();
+        let da = create_light_client_da_layer(&config.da, cancellation_token.clone())
+            .await
+            .map_err(|e| {
+                LightClientError::initialization_error(format!(
+                    "Failed to create light client DA: {}",
+                    e
+                ))
+            })?;
 
         let event_sub = da.event_channel().subscribe();
 
-        let light_client = create_light_client(da, &config.light_client, CancellationToken::new())
+        let light_client = create_light_client(da, &config.light_client, cancellation_token)
             .map_err(|e| {
                 LightClientError::initialization_error(format!(
                     "Failed to create light client: {}",

--- a/crates/tests/src/lib.rs
+++ b/crates/tests/src/lib.rs
@@ -77,8 +77,11 @@ async fn setup_da() -> (
         ..CelestiaLightClientDAConfig::default()
     });
 
-    let bridge_da_layer = create_full_node_da_layer(&bridge_cfg).await.unwrap();
-    let lc_da_layer = create_light_client_da_layer(&lc_cfg).await.unwrap();
+    let cancellation_token = CancellationToken::new();
+
+    let bridge_da_layer =
+        create_full_node_da_layer(&bridge_cfg, cancellation_token.clone()).await.unwrap();
+    let lc_da_layer = create_light_client_da_layer(&lc_cfg, cancellation_token).await.unwrap();
 
     (lc_da_layer, bridge_da_layer)
 }


### PR DESCRIPTION
closes #423

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS S3 data-availability backend for light clients and full nodes (WORM, cross-region, legal-hold support).
  * New CLI flag --allow_mock_proofs to control mock-proof verification.

* **Refactor**
  * Unified startup via LightDataAvailabilityLayer::start(); DA layers now start before syncing.
  * Added cancellation support and graceful shutdown across AWS, Celestia, and In-Memory backends; background height/produce tasks updated.

* **Documentation**
  * README updated to list multiple DA backends (includes Celestia) and AWS usage examples.

* **Chores**
  * Added AWS-related dependencies, feature gating, and workspace manifest updates; updated tests for new flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->